### PR TITLE
Add first-class analysis subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,27 @@ pip install -e ".[dev]"
 connascence analyze myfile.py
 
 # Analyze entire project
-connascence analyze .
+connascence analyze-workspace .
 
 # With safety profile
 connascence analyze . --profile strict
 
-# Generate HTML report
-connascence analyze . --format html --output report.html
+# Validate NASA compliance for one file
+connascence validate-safety src/flight.py --profile nasa-compliance
+
+# Generate refactoring suggestions for a hotspot line
+connascence suggest-refactoring src/utils.py --line 42
 ```
+
+### CLI verbs at a glance
+
+| Command | Description |
+|---------|-------------|
+| `analyze <file>` | AST-based connascence analysis for a single file or module |
+| `analyze-workspace <root>` | Recursively analyze a workspace (defaults to `*.py` patterns) |
+| `validate-safety <file>` | Run a safety profile/NASA compliance check and return structured violations |
+| `suggest-refactoring <file>` | Generate prioritized refactoring techniques for the most severe findings |
+| `scan` | **Legacy alias** for compatibility – prints a deprecation warning |
 
 ### VSCode Extension
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -4,6 +4,32 @@
 
 The connascence analyzer now provides a simple, flake8-style command-line interface that's easy to use while preserving all advanced functionality.
 
+## Modern Subcommands (shared with VSCode)
+
+Use the explicit verbs below for parity with the VSCode extension and the MCP bridge:
+
+| Command | When to use it |
+|---------|----------------|
+| `connascence analyze <file>` | Run AST connascence analysis for a single file or module |
+| `connascence analyze-workspace <root>` | Recursively analyze an entire workspace (defaults to Python files) |
+| `connascence validate-safety <file>` | Enforce a safety profile/NASA preset and emit violations |
+| `connascence suggest-refactoring <file>` | Generate prioritized refactoring techniques for the current file |
+| `connascence scan ...` | **Legacy alias** kept for backwards compatibility (prints a warning) |
+
+```bash
+# File analysis returned as JSON (default)
+connascence analyze src/service.py --profile strict --format json
+
+# Workspace analysis with explicit patterns and report output
+connascence analyze-workspace . --file-patterns "*.py" "*.pyi" --output workspace-report.json
+
+# NASA compliance validation (non-zero exit code if violations remain)
+connascence validate-safety avionics/control.py --profile nasa-compliance
+
+# Refactoring hints near a selected line
+connascence suggest-refactoring src/utils.py --line 128 --limit 3
+```
+
 ## Basic Usage (Flake8-style)
 
 ### Simple Commands


### PR DESCRIPTION
## Summary
- add explicit `analyze`, `analyze-workspace`, `validate-safety`, and `suggest-refactoring` subcommands to the connascence CLI and route them through the real AST analyzer
- emit structured JSON payloads for file, workspace, safety, and refactoring workflows while leaving the legacy `scan` verb as a deprecated alias
- document the shared CLI contract in the README and CLI usage guide so VSCode and CLI users have the same verbs

## Testing
- python interfaces/cli/connascence.py analyze README.md --format json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190f93d17c832cade01828ed65861c)