### PR TITLE
Ensure VS Code extension shares initialized service

### DIFF
--- a/interfaces/vscode/src/core/ConnascenceExtension.ts
+++ b/interfaces/vscode/src/core/ConnascenceExtension.ts
@@ -107,6 +107,10 @@ export class ConnascenceExtension {
         );
     }
 
+    public getConnascenceService(): ConnascenceService {
+        return this.connascenceService;
+    }
+
     public activate(): void {
         this.logger.info('Activating Connascence extension components...');
         


### PR DESCRIPTION
## Summary
- expose the instantiated `ConnascenceService` from `ConnascenceExtension` so other activation code can reuse it
- grab the service as soon as the extension is constructed and pass it through feature/command/tree/background initializers guarded by a helper
- guard workspace scanning/background bootstrap so UI pieces can safely request data as soon as they render

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file in interfaces/vscode/src)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190f8c47c8832c8c3b6e79034eceeb)