### PR TITLE
feat: add MCP server launcher and VSCode integration

### DIFF
--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -12,6 +12,27 @@ The Connascence Safety Analyzer can be run as an MCP (Model Context Protocol) se
 
 ## Quick Setup
 
+### Start the MCP backend from the CLI
+
+The analyzer CLI now bundles a launcher for the enhanced MCP backend:
+
+```bash
+# Start the websocket MCP server on the default port (8765)
+connascence mcp serve
+
+# Override host/port or pass environment variables through to the server
+connascence mcp serve --host 0.0.0.0 --port 9001 --env PYTHONUNBUFFERED=1 --env CONNASCENCE_PROFILE=vs-code
+
+# Check health from the same CLI (uses python -m mcp.cli health-check under the hood)
+connascence mcp status
+```
+
+Under the covers the CLI shells out to `python -m mcp.cli serve`, so you can invoke the Python module directly if you prefer:
+
+```bash
+python -m mcp.cli serve --port 9001
+```
+
 ### Claude Code / Claude Desktop Configuration
 
 Add to your MCP configuration (`C:\Users\<username>\AppData\Roaming\Claude\claude_desktop_config.json` on Windows):

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -27,6 +27,7 @@
     "onLanguage:typescript",
     "onCommand:connascence.analyze",
     "onCommand:connascence.showReport",
+    "onCommand:connascence.startMcpBackend",
     "onView:connascenceExplorer"
   ],
   "main": "./out/extension.js",
@@ -104,6 +105,12 @@
         "title": "Fix This Violation",
         "category": "Connascence",
         "icon": "$(check)"
+      },
+      {
+        "command": "connascence.startMcpBackend",
+        "title": "Start MCP Backend",
+        "category": "Connascence",
+        "icon": "$(debug-start)"
       }
     ],
     "menus": {

--- a/integrations/vscode/src/test/suite/extension.test.ts
+++ b/integrations/vscode/src/test/suite/extension.test.ts
@@ -25,5 +25,6 @@ suite('Extension Test Suite', () => {
         assert.ok(commands.includes('connascence.showReport'));
         assert.ok(commands.includes('connascence.fix'));
         assert.ok(commands.includes('connascence.configure'));
+        assert.ok(commands.includes('connascence.startMcpBackend'));
     });
 });

--- a/interfaces/cli/connascence.py
+++ b/interfaces/cli/connascence.py
@@ -20,6 +20,7 @@ after the core analyzer components were removed.
 
 import argparse
 from pathlib import Path
+import subprocess
 import sys
 from typing import List, Optional
 
@@ -168,7 +169,14 @@ class ConnascenceCLI:
 
         # MCP serve subcommand
         serve_parser = mcp_subparsers.add_parser("serve", help="Start MCP server")
-        serve_parser.add_argument("--port", type=int, default=8080, help="Server port")
+        serve_parser.add_argument("--host", default="127.0.0.1", help="Host/IP to bind (default: 127.0.0.1)")
+        serve_parser.add_argument("--port", type=int, default=8765, help="Server port (default: 8765)")
+        serve_parser.add_argument(
+            "--env",
+            action="append",
+            default=[],
+            help="Environment variable override passed to the MCP server (KEY=VALUE)",
+        )
 
         # MCP status subcommand
         status_parser = mcp_subparsers.add_parser("status", help="Show MCP server status")
@@ -523,11 +531,24 @@ class ConnascenceCLI:
         """Handle MCP command execution."""
         command = getattr(args, 'mcp_command', None)
         if command == 'serve':
-            port = getattr(args, 'port', 8080)
-            print(f"Starting MCP server on port {port}")
-        elif command == 'status':
-            print("MCP server status: not running")
-        return 0
+            host = getattr(args, 'host', '127.0.0.1')
+            port = getattr(args, 'port', 8765)
+            env_args = getattr(args, 'env', []) or []
+
+            cmd = [sys.executable, '-m', 'mcp.cli', 'serve', '--host', host, '--port', str(port)]
+            for env_var in env_args:
+                cmd.extend(['--env', env_var])
+
+            result = subprocess.run(cmd, check=False)
+            return result.returncode
+
+        if command == 'status':
+            cmd = [sys.executable, '-m', 'mcp.cli', 'health-check']
+            result = subprocess.run(cmd, check=False)
+            return result.returncode
+
+        print("Unknown MCP subcommand", file=sys.stderr)
+        return ExitCode.ERROR
 
     def _load_or_scan_violations(self, args: argparse.Namespace = None):
         """Load violations from scan or existing results."""

--- a/mcp/websocket_server.py
+++ b/mcp/websocket_server.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024 Connascence Safety Analyzer Contributors
+
+"""WebSocket server wrapper for the enhanced MCP backend."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional, Set
+
+try:
+    import websockets
+    from websockets.server import Serve, WebSocketServerProtocol
+except ImportError as exc:  # pragma: no cover - surfaced during CLI invocation
+    raise RuntimeError(
+        "The 'websockets' package is required to start the MCP WebSocket server. "
+        "Install it via 'pip install websockets' or run 'pip install -r requirements.txt'."
+    ) from exc
+
+from mcp.enhanced_server import create_enhanced_mcp_server, get_server_info
+
+logger = logging.getLogger(__name__)
+
+
+class MCPWebSocketServer:
+    """Thin WebSocket layer that exposes the enhanced MCP server."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 8765, config: Optional[Dict[str, Any]] = None):
+        self.host = host
+        self.port = port
+        self.config = config or {}
+        self._ws_server: Optional[Serve] = None
+        self._clients: Set[WebSocketServerProtocol] = set()
+        self._backend = create_enhanced_mcp_server(self.config)
+        self._server_info = get_server_info()
+
+    async def start(self) -> None:
+        """Start accepting WebSocket connections."""
+
+        async def handler(websocket: WebSocketServerProtocol):
+            await self._handle_client(websocket)
+
+        self._ws_server = await websockets.serve(handler, self.host, self.port, ping_interval=30, ping_timeout=30)
+        logger.info("MCP WebSocket server listening on %s:%s", self.host, self.port)
+
+    async def stop(self) -> None:
+        """Stop the WebSocket server and disconnect clients."""
+        if self._ws_server is not None:
+            self._ws_server.close()
+            await self._ws_server.wait_closed()
+            self._ws_server = None
+
+        await asyncio.gather(*(self._close_client(client) for client in list(self._clients)), return_exceptions=True)
+
+    async def _close_client(self, websocket: WebSocketServerProtocol) -> None:
+        try:
+            await websocket.close()
+        except Exception:  # pragma: no cover - best effort close
+            pass
+
+    async def _handle_client(self, websocket: WebSocketServerProtocol) -> None:
+        self._clients.add(websocket)
+        logger.debug("New MCP client connected (%s active)", len(self._clients))
+        try:
+            await websocket.send(
+                json.dumps(
+                    {
+                        "type": "welcome",
+                        "server": self._server_info,
+                    }
+                )
+            )
+
+            async for raw_message in websocket:
+                await self._dispatch_message(websocket, raw_message)
+        except websockets.ConnectionClosedOK:
+            logger.debug("MCP client disconnected cleanly")
+        except websockets.ConnectionClosedError as error:
+            logger.warning("MCP client disconnected with error: %s", error)
+        finally:
+            self._clients.discard(websocket)
+            logger.debug("MCP client disconnected (%s active)", len(self._clients))
+
+    async def _dispatch_message(self, websocket: WebSocketServerProtocol, raw_message: str) -> None:
+        try:
+            message = json.loads(raw_message)
+        except json.JSONDecodeError:
+            await websocket.send(
+                json.dumps({"type": "error", "error": "Invalid JSON payload", "requestId": None})
+            )
+            return
+
+        message_type = message.get("type")
+        request_id = message.get("requestId")
+
+        if message_type == "register":
+            await websocket.send(
+                json.dumps(
+                    {
+                        "type": "registered",
+                        "status": "ok",
+                        "requestId": request_id,
+                        "server": self._server_info,
+                    }
+                )
+            )
+            return
+
+        if message_type in {"health", "health_check"}:
+            health = await self._backend.health_check()
+            status = "ok" if health.get("success") else "error"
+            await websocket.send(
+                json.dumps(
+                    {
+                        "type": "health",
+                        "status": status,
+                        "requestId": request_id,
+                        "details": health,
+                    }
+                )
+            )
+            return
+
+        if message_type == "analyze":
+            file_path = message.get("filePath")
+            if not file_path:
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "type": "analysis_result",
+                            "requestId": request_id,
+                            "error": "Missing filePath for analysis",
+                        }
+                    )
+                )
+                return
+
+            options = message.get("options") or {}
+            result = await self._backend.analyze_file(file_path=file_path, **options)
+            await websocket.send(
+                json.dumps(
+                    {
+                        "type": "analysis_result",
+                        "requestId": request_id,
+                        "data": result,
+                        "error": None if result.get("success") else result.get("error"),
+                    }
+                )
+            )
+            return
+
+        if message_type == "ping":
+            await websocket.send(json.dumps({"type": "pong", "requestId": request_id}))
+            return
+
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "error",
+                    "requestId": request_id,
+                    "error": f"Unknown MCP message type: {message_type}",
+                }
+            )
+        )
+
+
+__all__ = ["MCPWebSocketServer"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "rich>=12.0.0",
     "pathspec>=0.10.0",
     "psutil>=5.9.0",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ click>=8.0.0
 rich>=12.0.0
 pathspec>=0.10.0
 psutil>=5.9.0
+websockets>=12.0
 
 # Tree-sitter dependencies for multi-language analysis (optional)
 # Uncomment to enable tree-sitter support:


### PR DESCRIPTION
## Summary
- add an asyncio-based WebSocket wrapper for the enhanced MCP backend and expose it through `python -m mcp.cli serve`
- teach both CLI entry points to launch/monitor the new MCP server, add env/port overrides, update docs and tests, and document the workflow
- upgrade the VS Code extension with a dedicated “Start MCP Backend” command plus improved MCP client health handshakes

## Testing
- `pytest tests/test_cli.py -k mcp -q`
- `npm --prefix integrations/vscode test --silent` *(fails: unable to download VS Code test binary in the sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190f9b82a0832ca51de7edc8651459)