### PR TITLE
Add shared analyzer entry point and align integrations

### DIFF
--- a/analyzer/cli_entry.py
+++ b/analyzer/cli_entry.py
@@ -1,0 +1,201 @@
+"""Shared CLI entry point for the unified analyzer.
+
+This module centralizes the logic used by the standalone CLI, VS Code
+extension, and MCP server so they all emit the exact same JSON schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+from analyzer.unified_analyzer import UnifiedConnascenceAnalyzer
+
+CLI_SCHEMA_VERSION = "2024-08-01"
+
+
+@dataclass
+class CLIAnalysisRequest:
+    """Normalized request used by every entry point."""
+
+    input_path: str
+    mode: str = "file"  # "file" or "workspace"
+    policy: str = "service-defaults"
+    include_tests: bool = False
+    exclude: List[str] = field(default_factory=list)
+    threshold: Optional[float] = None
+    parallel: bool = False
+    max_workers: Optional[int] = None
+    format: str = "json"
+
+
+@dataclass
+class CLIAnalysisResponse:
+    """Standard JSON payload shared by CLI, MCP, and VSCode."""
+
+    schema_version: str
+    success: bool
+    request: CLIAnalysisRequest
+    result: Dict[str, Any]
+    summary: Dict[str, Any]
+    metadata: Dict[str, Any]
+    duration_ms: int
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["request"] = asdict(self.request)
+        return data
+
+    def to_json(self, indent: Optional[int] = None) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+_SHARED_ANALYZER: Optional[UnifiedConnascenceAnalyzer] = None
+
+
+def _get_analyzer() -> UnifiedConnascenceAnalyzer:
+    global _SHARED_ANALYZER
+    if _SHARED_ANALYZER is None:
+        _SHARED_ANALYZER = UnifiedConnascenceAnalyzer()
+    return _SHARED_ANALYZER
+
+
+def _build_summary(result: Dict[str, Any]) -> Dict[str, Any]:
+    severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for violation in result.get("connascence_violations", []):
+        severity = str(violation.get("severity", "low")).lower()
+        if severity in severity_counts:
+            severity_counts[severity] += 1
+    total = result.get("total_violations")
+    if total is None:
+        total = len(result.get("connascence_violations", []))
+    return {
+        "total_violations": total,
+        "severity_breakdown": severity_counts,
+    }
+
+
+def _build_metadata(request: CLIAnalysisRequest, duration_ms: int) -> Dict[str, Any]:
+    return {
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "schema_version": CLI_SCHEMA_VERSION,
+        "mode": request.mode,
+        "policy": request.policy,
+        "duration_ms": duration_ms,
+    }
+
+
+def run_cli_analysis(request: CLIAnalysisRequest) -> CLIAnalysisResponse:
+    """Execute analysis with shared configuration."""
+
+    analyzer = _get_analyzer()
+    start = time.time()
+    path = Path(request.input_path)
+
+    options = {
+        "parallel": request.parallel,
+        "max_workers": request.max_workers,
+        "include_tests": request.include_tests,
+        "exclude": request.exclude,
+    }
+    if request.threshold is not None:
+        options["threshold"] = request.threshold
+
+    try:
+        if request.mode == "file" and path.is_file():
+            raw_result = analyzer.analyze_file(str(path))
+        else:
+            raw_result = analyzer.analyze_project(str(path), request.policy, options)
+
+        result_dict = raw_result.to_dict() if hasattr(raw_result, "to_dict") else raw_result
+        duration_ms = int((time.time() - start) * 1000)
+        summary = _build_summary(result_dict)
+        metadata = _build_metadata(request, duration_ms)
+        return CLIAnalysisResponse(
+            schema_version=CLI_SCHEMA_VERSION,
+            success=True,
+            request=request,
+            result=result_dict,
+            summary=summary,
+            metadata=metadata,
+            duration_ms=duration_ms,
+        )
+    except Exception as exc:  # pragma: no cover - surfaced through response
+        duration_ms = int((time.time() - start) * 1000)
+        metadata = _build_metadata(request, duration_ms)
+        metadata["exception_type"] = type(exc).__name__
+        return CLIAnalysisResponse(
+            schema_version=CLI_SCHEMA_VERSION,
+            success=False,
+            request=request,
+            result={},
+            summary={},
+            metadata=metadata,
+            duration_ms=duration_ms,
+            errors=[str(exc)],
+        )
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("path", nargs="?", default=".", help="Path to analyze")
+    parser.add_argument("--policy", dest="policy", default="service-defaults", help="Policy preset")
+    parser.add_argument("--format", choices=["json", "text"], default="json", help="Output format")
+    parser.add_argument("--include-tests", action="store_true", help="Include test files")
+    parser.add_argument("--exclude", nargs="*", default=[], help="Exclude glob patterns")
+    parser.add_argument("--threshold", type=float, help="Quality threshold override")
+    parser.add_argument("--parallel", action="store_true", help="Enable parallel analysis")
+    parser.add_argument("--max-workers", type=int, help="Maximum worker processes")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Shared analyzer CLI entry")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    analyze_parser = subparsers.add_parser("analyze", help="Analyze a single file or directory")
+    _add_common_arguments(analyze_parser)
+
+    workspace_parser = subparsers.add_parser("analyze-workspace", help="Analyze entire workspace")
+    _add_common_arguments(workspace_parser)
+
+    return parser
+
+
+def _request_from_args(args: argparse.Namespace) -> CLIAnalysisRequest:
+    return CLIAnalysisRequest(
+        input_path=args.path,
+        mode="file" if args.command == "analyze" else "workspace",
+        policy=args.policy,
+        include_tests=args.include_tests,
+        exclude=list(args.exclude) if isinstance(args.exclude, list) else [],
+        threshold=args.threshold,
+        parallel=args.parallel,
+        max_workers=args.max_workers,
+        format=args.format,
+    )
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    request = _request_from_args(args)
+    response = run_cli_analysis(request)
+
+    if request.format == "json":
+        print(response.to_json(indent=2))
+    else:
+        print(f"Analysis success: {response.success}")
+        print(json.dumps(response.summary, indent=2))
+
+    return 0 if response.success else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    sys.exit(main())

--- a/interfaces/vscode/package.json
+++ b/interfaces/vscode/package.json
@@ -838,6 +838,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
+    "unit:test": "npm run compile && node ./out/test/reportTransforms.spec.js",
     "package": "vsce package",
     "publish": "vsce publish",
     "build:production": "npm run compile && npm run lint && npm run test"

--- a/interfaces/vscode/src/services/reportTransforms.ts
+++ b/interfaces/vscode/src/services/reportTransforms.ts
@@ -1,0 +1,291 @@
+import * as path from 'path';
+import { AnalysisResult, Finding, PerformanceMetrics, DuplicationCluster, NASAComplianceResult, SmartIntegrationResult } from './connascenceService';
+
+export function mapSeverity(severity: string): 'critical' | 'major' | 'minor' | 'info' {
+    const severityMap: { [key: string]: 'critical' | 'major' | 'minor' | 'info' } = {
+        'critical': 'critical',
+        'high': 'major',
+        'medium': 'minor',
+        'low': 'info',
+        'error': 'critical',
+        'warning': 'major',
+        'info': 'info'
+    };
+
+    return severityMap[severity.toLowerCase()] || 'info';
+}
+
+export function calculateSeverityBreakdown(findings: Finding[]): {
+    critical: number;
+    major: number;
+    minor: number;
+    info: number;
+} {
+    return findings.reduce((acc, finding) => {
+        acc[finding.severity]++;
+        return acc;
+    }, { critical: 0, major: 0, minor: 0, info: 0 });
+}
+
+export function calculateQualityScore(findings: Finding[]): number {
+    if (findings.length === 0) return 100;
+
+    const weights = { critical: 10, major: 5, minor: 2, info: 1 };
+    const totalWeight = findings.reduce((sum, f) => sum + weights[f.severity], 0);
+
+    return Math.max(0, 100 - totalWeight);
+}
+
+export function calculateOverallQualityScore(fileResults: { [filePath: string]: AnalysisResult }): number {
+    const scores = Object.values(fileResults).map(r => r.qualityScore);
+    return scores.length > 0 ? scores.reduce((sum, score) => sum + score, 0) / scores.length : 100;
+}
+
+export function calculateEnhancedQualityScore(
+    findings: Finding[],
+    duplicationClusters: DuplicationCluster[],
+    nasaCompliance: NASAComplianceResult
+): number {
+    let baseScore = calculateQualityScore(findings);
+
+    const duplicationPenalty = duplicationClusters.length * 5;
+    baseScore = Math.max(0, baseScore - duplicationPenalty);
+
+    const compliancePenalty = (1.0 - nasaCompliance.score) * 20;
+    baseScore = Math.max(0, baseScore - compliancePenalty);
+
+    return Math.round(baseScore);
+}
+
+export function calculateClusterSeverity(similarity: number): 'critical' | 'major' | 'minor' | 'info' {
+    if (similarity >= 0.9) return 'critical';
+    if (similarity >= 0.8) return 'major';
+    if (similarity >= 0.7) return 'minor';
+    return 'info';
+}
+
+export function calculateOverallRisk(report: any): 'low' | 'medium' | 'high' | 'critical' {
+    const criticalViolations = (report.connascence_violations || []).filter((v: any) =>
+        v.severity === 'critical'
+    ).length;
+
+    const highSimilarityClusters = (report.duplication_clusters || []).filter((c: any) =>
+        c.similarity_score >= 0.9
+    ).length;
+
+    const nasaViolations = (report.nasa_violations || []).length;
+
+    if (criticalViolations > 10 || highSimilarityClusters > 5 || nasaViolations > 20) {
+        return 'critical';
+    } else if (criticalViolations > 5 || highSimilarityClusters > 2 || nasaViolations > 10) {
+        return 'high';
+    } else if (criticalViolations > 0 || highSimilarityClusters > 0 || nasaViolations > 0) {
+        return 'medium';
+    }
+
+    return 'low';
+}
+
+export function convertUnifiedReportToAnalysisResult(report: any, filePath: string, startTime: number): AnalysisResult {
+    const findings: Finding[] = [];
+
+    if (report.connascence_violations) {
+        for (const violation of report.connascence_violations) {
+            if (!violation.file_path || path.resolve(violation.file_path) !== path.resolve(filePath)) {
+                continue;
+            }
+
+            findings.push({
+                id: violation.id || `${violation.type}_${violation.line_number}`,
+                type: violation.type || violation.rule_id,
+                severity: mapSeverity(violation.severity),
+                message: violation.description,
+                file: violation.file_path,
+                line: violation.line_number,
+                column: violation.column_number,
+                suggestion: violation.suggestion
+            });
+        }
+    }
+
+    const performanceMetrics: PerformanceMetrics = {
+        analysisTime: Date.now() - startTime,
+        parallelProcessing: report.parallel_processing || false,
+        speedupFactor: report.speedup_factor || 1.0,
+        workerCount: report.worker_count || 1,
+        memoryUsage: report.peak_memory_mb || 0,
+        efficiency: report.efficiency || 1.0
+    };
+
+    const duplicationClusters: DuplicationCluster[] = (report.duplication_clusters || []).map((cluster: any) => ({
+        id: cluster.id,
+        blocks: cluster.blocks.map((block: any) => ({
+            file: block.file_path,
+            startLine: block.start_line,
+            endLine: block.end_line,
+            content: block.content || '',
+            hash: block.hash_signature || ''
+        })),
+        similarity: cluster.similarity_score,
+        severity: calculateClusterSeverity(cluster.similarity_score),
+        description: cluster.description,
+        files: cluster.files_involved || []
+    }));
+
+    const nasaCompliance: NASAComplianceResult = {
+        compliant: (report.nasa_compliance_score || 1.0) >= 0.8,
+        score: report.nasa_compliance_score || 1.0,
+        violations: (report.nasa_violations || []).map((v: any) => ({
+            rule: v.rule,
+            message: v.message,
+            file: v.file_path || filePath,
+            line: v.line_number || 0,
+            severity: mapSeverity(v.severity),
+            powerOfTenRule: v.power_of_ten_rule
+        })),
+        powerOfTenRules: report.power_of_ten_rules || []
+    };
+
+    const smartIntegrationResults: SmartIntegrationResult = {
+        crossAnalyzerCorrelation: report.correlations || [],
+        intelligentRecommendations: (report.improvement_actions || []).map((action: string, index: number) => ({
+            priority: index < 2 ? 'high' as const : 'medium' as const,
+            category: 'quality_improvement',
+            description: action,
+            impact: 'Improves code quality and maintainability',
+            effort: 'medium' as const,
+            suggestedActions: [action]
+        })),
+        qualityTrends: [{
+            metric: 'overall_quality',
+            current: report.overall_quality_score || 0.8,
+            trend: 'stable' as const,
+            projection: report.overall_quality_score || 0.8
+        }],
+        riskAssessment: {
+            overallRisk: calculateOverallRisk(report),
+            riskFactors: [],
+            mitigation: report.priority_fixes || []
+        }
+    };
+
+    return {
+        findings,
+        qualityScore: Math.round((report.overall_quality_score || 0.8) * 100),
+        summary: {
+            totalIssues: findings.length + duplicationClusters.length + nasaCompliance.violations.length,
+            issuesBySeverity: calculateSeverityBreakdown(findings)
+        },
+        performanceMetrics,
+        duplicationClusters,
+        nasaCompliance,
+        smartIntegrationResults
+    };
+}
+
+export function convertUnifiedWorkspaceResult(report: any, startTime: number): {
+    fileResults: { [filePath: string]: AnalysisResult },
+    summary: { filesAnalyzed: number, totalIssues: number, qualityScore: number }
+} {
+    const fileResults: { [filePath: string]: AnalysisResult } = {};
+    let totalIssues = 0;
+
+    const violationsByFile = new Map<string, any[]>();
+    if (report.connascence_violations) {
+        for (const violation of report.connascence_violations) {
+            const file = violation.file_path || 'unknown';
+            if (!violationsByFile.has(file)) {
+                violationsByFile.set(file, []);
+            }
+            violationsByFile.get(file)!.push(violation);
+        }
+    }
+
+    for (const [file, violations] of violationsByFile) {
+        const findings: Finding[] = violations.map(v => ({
+            id: v.id || `${v.type}_${v.line_number}`,
+            type: v.type || v.rule_id,
+            severity: mapSeverity(v.severity),
+            message: v.description,
+            file: v.file_path,
+            line: v.line_number,
+            column: v.column_number,
+            suggestion: v.suggestion
+        }));
+
+        const fileDuplicationClusters = (report.duplication_clusters || []).filter((cluster: any) =>
+            cluster.files_involved && cluster.files_involved.includes(file)
+        ).map((cluster: any) => ({
+            id: cluster.id,
+            blocks: cluster.blocks.filter((block: any) => block.file_path === file),
+            similarity: cluster.similarity_score,
+            severity: calculateClusterSeverity(cluster.similarity_score),
+            description: cluster.description,
+            files: [file]
+        }));
+
+        const fileNasaViolations = (report.nasa_violations || []).filter((v: any) =>
+            v.file_path === file
+        ).map((v: any) => ({
+            rule: v.rule,
+            message: v.message,
+            file: v.file_path,
+            line: v.line_number,
+            severity: mapSeverity(v.severity),
+            powerOfTenRule: v.power_of_ten_rule
+        }));
+
+        const performanceMetrics: PerformanceMetrics = {
+            analysisTime: Date.now() - startTime,
+            parallelProcessing: report.parallel_processing || false,
+            speedupFactor: report.speedup_factor || 1.0,
+            workerCount: report.worker_count || 1,
+            memoryUsage: report.peak_memory_mb || 0,
+            efficiency: report.efficiency || 1.0
+        };
+
+        const nasaCompliance: NASAComplianceResult = {
+            compliant: fileNasaViolations.length === 0,
+            score: Math.max(0, 1.0 - (fileNasaViolations.length * 0.1)),
+            violations: fileNasaViolations,
+            powerOfTenRules: []
+        };
+
+        const smartIntegrationResults: SmartIntegrationResult = {
+            crossAnalyzerCorrelation: [],
+            intelligentRecommendations: [],
+            qualityTrends: [],
+            riskAssessment: {
+                overallRisk: findings.filter(f => f.severity === 'critical').length > 0 ? 'high' : 'low',
+                riskFactors: [],
+                mitigation: []
+            }
+        };
+
+        const totalFileIssues = findings.length + fileDuplicationClusters.length + fileNasaViolations.length;
+
+        fileResults[file] = {
+            findings,
+            qualityScore: calculateEnhancedQualityScore(findings, fileDuplicationClusters, nasaCompliance),
+            summary: {
+                totalIssues: totalFileIssues,
+                issuesBySeverity: calculateSeverityBreakdown(findings)
+            },
+            performanceMetrics,
+            duplicationClusters: fileDuplicationClusters,
+            nasaCompliance,
+            smartIntegrationResults
+        };
+
+        totalIssues += totalFileIssues;
+    }
+
+    return {
+        fileResults,
+        summary: {
+            filesAnalyzed: Object.keys(fileResults).length,
+            totalIssues,
+            qualityScore: Math.round((report.overall_quality_score || 0.8) * 100)
+        }
+    };
+}

--- a/interfaces/vscode/src/test/reportTransforms.spec.ts
+++ b/interfaces/vscode/src/test/reportTransforms.spec.ts
@@ -1,0 +1,92 @@
+import * as assert from 'assert';
+import { convertUnifiedReportToAnalysisResult, convertUnifiedWorkspaceResult } from '../services/reportTransforms';
+
+function testSingleFileTransform() {
+    const sampleReport = {
+        connascence_violations: [
+            {
+                id: 'v1',
+                type: 'CoM',
+                severity: 'high',
+                description: 'Magic literal',
+                file_path: '/tmp/example.py',
+                line_number: 5
+            },
+            {
+                id: 'v2',
+                type: 'CoP',
+                severity: 'medium',
+                description: 'Parameter explosion',
+                file_path: '/tmp/other.py',
+                line_number: 12
+            }
+        ],
+        duplication_clusters: [
+            {
+                id: 'c1',
+                blocks: [
+                    { file_path: '/tmp/example.py', start_line: 20, end_line: 30 },
+                    { file_path: '/tmp/example.py', start_line: 40, end_line: 50 }
+                ],
+                similarity_score: 0.92,
+                description: 'Duplicated logic',
+                files_involved: ['/tmp/example.py']
+            }
+        ],
+        nasa_violations: [
+            {
+                rule: 'PO10',
+                message: 'Dynamic memory',
+                file_path: '/tmp/example.py',
+                line_number: 9,
+                severity: 'critical',
+                power_of_ten_rule: '4'
+            }
+        ],
+        overall_quality_score: 0.77,
+        parallel_processing: true,
+        worker_count: 4,
+        efficiency: 1.1,
+        improvement_actions: ['Refactor duplicated logic'],
+        priority_fixes: ['Remove global state']
+    };
+
+    const result = convertUnifiedReportToAnalysisResult(sampleReport, '/tmp/example.py', Date.now());
+    assert.strictEqual(result.findings.length, 1, 'should filter to file specific violations');
+    const clusters = result.duplicationClusters || [];
+    const nasa = result.nasaCompliance;
+    if (!nasa) {
+        throw new Error('Missing NASA compliance data');
+    }
+    assert.ok(clusters[0].severity === 'critical', 'high similarity cluster severity');
+    assert.strictEqual(nasa.violations.length, 1, 'NASA violations should surface');
+    assert.strictEqual(result.summary.totalIssues, result.findings.length + clusters.length + nasa.violations.length);
+}
+
+function testWorkspaceTransform() {
+    const sampleReport = {
+        connascence_violations: [
+            { id: 'v1', type: 'CoM', severity: 'high', description: 'Magic literal', file_path: '/tmp/a.py', line_number: 1 },
+            { id: 'v2', type: 'CoP', severity: 'low', description: 'Parameters', file_path: '/tmp/b.py', line_number: 2 }
+        ],
+        duplication_clusters: [
+            { id: 'c1', blocks: [{ file_path: '/tmp/a.py', start_line: 10, end_line: 15 }], similarity_score: 0.8, description: 'dup block', files_involved: ['/tmp/a.py'] }
+        ],
+        nasa_violations: [],
+        overall_quality_score: 0.9
+    };
+
+    const workspace = convertUnifiedWorkspaceResult(sampleReport, Date.now());
+    assert.strictEqual(workspace.summary.filesAnalyzed, 2, 'two files processed');
+    assert.strictEqual(Object.keys(workspace.fileResults).length, 2, 'should return per-file results');
+    const fileA = workspace.fileResults['/tmp/a.py'];
+    assert.ok(fileA.summary.totalIssues >= 1, 'file should include issues');
+}
+
+function run() {
+    testSingleFileTransform();
+    testWorkspaceTransform();
+    console.log('reportTransforms.spec.ts: all tests passed');
+}
+
+run();

--- a/tests/test_cli_shared_entry.py
+++ b/tests/test_cli_shared_entry.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from analyzer.cli_entry import CLIAnalysisRequest, run_cli_analysis
+
+
+def test_cli_analyze_json_output():
+    target = Path('tests') / 'sample_for_cli.py'
+    assert target.exists(), 'sample file should exist'
+
+    request = CLIAnalysisRequest(input_path=str(target), mode='file')
+    response = run_cli_analysis(request)
+
+    assert response.schema_version == '2024-08-01'
+    assert response.success is True
+    assert response.metadata['policy'] == request.policy
+    assert response.summary['total_violations'] >= 0
+    assert 'generated_at' in response.metadata

--- a/tests/test_mcp_cli_bridge.py
+++ b/tests/test_mcp_cli_bridge.py
@@ -1,0 +1,21 @@
+import asyncio
+from pathlib import Path
+
+from mcp.enhanced_server import EnhancedConnascenceMCPServer
+
+
+def run_async(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_mcp_server_uses_cli_schema(tmp_path):
+    server = EnhancedConnascenceMCPServer({})
+    sample_file = Path('tests') / 'sample_for_cli.py'
+    assert sample_file.exists()
+
+    response = run_async(server.analyze_file(str(sample_file)))
+    assert response['success'] is True
+    assert 'metadata' in response
+    assert response['metadata'].get('schema_version') == '2024-08-01'
+    assert 'violations' in response
+    assert response['summary']['total_violations'] == len(response['violations'])


### PR DESCRIPTION
## Summary
- add `analyzer/cli_entry.py` to expose a shared JSON schema for the CLI, MCP server, and VS Code tooling
- update the CLI, MCP server, and VS Code `ConnascenceApiClient` to invoke the shared entry point (including new report transformer utilities)
- add regression tests for the CLI schema, MCP bridge, and VS Code result transformers to keep UI data consistent

## Testing
- `npm --prefix interfaces/vscode run unit:test` (passes)  
- `pytest tests/test_cli_shared_entry.py tests/test_mcp_cli_bridge.py` (passes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190fa3a110832ca99c1ac20bc934db)