### PR TITLE
Add analyzer verification scripts and wrappers

### DIFF
--- a/scripts/analyze_connascence.py
+++ b/scripts/analyze_connascence.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Run the Connascence Analyzer across a target path and emit Co* summaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Dict
+
+# Ensure project root is on the path so we can import analyzer modules
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from analyzer.check_connascence import ConnascenceAnalyzer  # noqa: E402
+
+# Mapping between analyzer violation types and Connascence shorthand codes
+TYPE_TO_CODE = {
+    "connascence_of_position": "CoP",
+    "connascence_of_name": "CoN",
+    "connascence_of_type": "CoT",
+    "connascence_of_meaning": "CoM",
+    "connascence_of_algorithm": "CoA",
+    "connascence_of_execution": "CoE",
+    "connascence_of_values": "CoV",
+    "connascence_of_identity": "CoI",
+    "connascence_of_timing": "CoTiming",
+    "connascence_of_convention": "CoConvention",
+}
+
+ORDERED_CODES = [
+    "CoP",
+    "CoN",
+    "CoT",
+    "CoM",
+    "CoA",
+    "CoE",
+    "CoV",
+    "CoI",
+    "CoTiming",
+    "CoConvention",
+]
+
+
+def _collect_connascence(path: Path) -> list:
+    """Collect connascence violations for a given path."""
+
+    analyzer = ConnascenceAnalyzer(exclusions=[])  # include test files intentionally
+    if path.is_file():
+        return analyzer.analyze_file(path)
+    return analyzer.analyze_directory(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Connascence Analyzer wrapper")
+    parser.add_argument("path", help="Path to analyze (file or directory)")
+    args = parser.parse_args()
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"[ERROR] Path not found: {target}")
+        return 2
+
+    violations = _collect_connascence(target)
+
+    counts: Dict[str, int] = {code: 0 for code in ORDERED_CODES}
+    counts["Other"] = 0
+
+    for violation in violations:
+        vtype = violation.type or violation.connascence_type or ""
+        shorthand = TYPE_TO_CODE.get(vtype, "Other")
+        counts.setdefault(shorthand, 0)
+        counts[shorthand] += 1
+
+    total = sum(counts.values())
+
+    print("Connascence Analyzer Results")
+    print("=" * 40)
+    for code in ORDERED_CODES:
+        print(f"{code}: {counts.get(code, 0)} violations")
+    print(f"Other/auxiliary findings: {counts.get('Other', 0)}")
+    print("-" * 40)
+    print(f"Total connascence findings: {total}")
+
+    # Emit JSON summary for downstream tooling
+    summary = {
+        "total": total,
+        "violations": {code: counts.get(code, 0) for code in ORDERED_CODES},
+    }
+    print("\nJSON Summary:")
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyze_mece.py
+++ b/scripts/analyze_mece.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Run the MECE duplication analyzer over a path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from analyzer.dup_detection.mece_analyzer import MECEAnalyzer  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MECE duplication analyzer wrapper")
+    parser.add_argument("path", help="Path to analyze")
+    parser.add_argument("--comprehensive", action="store_true", help="Use comprehensive mode")
+    parser.add_argument("--threshold", type=float, default=0.75, help="Similarity threshold")
+    args = parser.parse_args()
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"[ERROR] Path not found: {target}")
+        return 2
+
+    analyzer = MECEAnalyzer(threshold=args.threshold)
+    result = analyzer.analyze_path(str(target), comprehensive=args.comprehensive)
+
+    if not result.get("success"):
+        print(f"[ERROR] MECE analysis failed: {result.get('error')}")
+        return 1
+
+    duplications = result.get("duplications", [])
+    print("MECE Duplication Analyzer Results")
+    print("=" * 40)
+    for cluster in duplications:
+        description = cluster.get("description", "Code duplication detected")
+        similarity = cluster.get("similarity_score", 0.0)
+        print(
+            f"DUPLICATE cluster {cluster.get('id', 'n/a')}: {description} "
+            f"(similarity {similarity:.2f})"
+        )
+        if cluster.get("functions"):
+            print(f"  Similar functions: {', '.join(cluster['functions'])}")
+        if cluster.get("overlap_lines"):
+            print(f"  Overlapping logic spans: {cluster['overlap_lines']}")
+
+    print("-" * 40)
+    print(f"Total duplicate clusters: {len(duplications)}")
+    print(json.dumps(result.get("summary", {}), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyze_nasa_safety.py
+++ b/scripts/analyze_nasa_safety.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Run NASA Power of Ten safety analysis over a target path."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from analyzer.nasa_engine.nasa_analyzer import NASAAnalyzer  # noqa: E402
+
+VIOLATION_MAP = {
+    "goto_statement": "goto",
+    "recursive_function": "recursion",
+    "unbounded_loop": "loop bound",
+    "malloc_after_init": "heap allocation",
+    "function_too_long": "loop bound",
+    "insufficient_assertions": "assertion",
+    "variable_scope_too_wide": "scope",
+    "unchecked_return_value": "assertion",
+}
+
+
+def _gather_violations(analyzer: NASAAnalyzer, target: Path) -> list:
+    violations = []
+    if target.is_file() and target.suffix == ".py":
+        violations.extend(analyzer.analyze_file(str(target)))
+        return violations
+
+    for py_file in target.rglob("*.py"):
+        violations.extend(analyzer.analyze_file(str(py_file)))
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="NASA Power of Ten analyzer")
+    parser.add_argument("path", help="Path to analyze")
+    args = parser.parse_args()
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"[ERROR] Path not found: {target}")
+        return 2
+
+    analyzer = NASAAnalyzer()
+    violations = _gather_violations(analyzer, target)
+
+    counts = Counter()
+    for violation in violations:
+        label = VIOLATION_MAP.get(violation.type, violation.type)
+        counts[label] += 1
+
+    print("NASA Power of Ten Results")
+    print("=" * 40)
+    print(f"Loop bound issues: {counts.get('loop bound', 0)}")
+    print(f"Recursion violations: {counts.get('recursion', 0)}")
+    print(f"Goto statements detected: {counts.get('goto', 0)}")
+    print(f"Heap allocation flags: {counts.get('heap allocation', 0)}")
+    print(f"Assertion density issues: {counts.get('assertion', 0)}")
+    print(f"Unchecked scope violations: {counts.get('scope', 0)}")
+    print(f"Total NASA rule alerts: {sum(counts.values())}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyze_six_sigma.py
+++ b/scripts/analyze_six_sigma.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Run Six Sigma analysis on connascence violations for a path."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from analyzer.check_connascence import ConnascenceAnalyzer  # noqa: E402
+from analyzer.enterprise.sixsigma.analyzer import SixSigmaAnalyzer  # noqa: E402
+
+
+def _collect_connascence_dicts(path: Path) -> list[dict]:
+    analyzer = ConnascenceAnalyzer(exclusions=[])
+    if path.is_file():
+        violations = analyzer.analyze_file(path)
+    else:
+        violations = analyzer.analyze_directory(path)
+    return [v.to_dict() for v in violations]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Six Sigma analyzer wrapper")
+    parser.add_argument("path", help="Path to analyze")
+    parser.add_argument("--target", default="enterprise", help="Six Sigma quality target")
+    args = parser.parse_args()
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"[ERROR] Path not found: {target}")
+        return 2
+
+    violations = _collect_connascence_dicts(target)
+    sixsigma = SixSigmaAnalyzer(target_level=args.target)
+    result = sixsigma.analyze_violations(violations, file_path=target)
+
+    print("Six Sigma Quality Metrics")
+    print("=" * 40)
+    print(f"Quality defects detected: {len(violations)}")
+    print(f"DPMO: {result.dpmo:.2f} | Sigma Level: {result.sigma_level:.2f}")
+    outliers = 1 if result.sigma_level < sixsigma.target_level["sigma"] else 0
+    print(f"Statistical outliers (sigma shortfalls): {outliers}")
+    cp, cpk = result.process_capability
+    print(f"Process variation (Cp/Cpk): {cp:.2f}/{cpk:.2f}")
+    print(f"Yield (RTY): {result.rty:.2f}%")
+
+    if result.improvement_suggestions:
+        print("\nImprovement suggestions:")
+        for suggestion in result.improvement_suggestions:
+            print(f"- {suggestion}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/detect_god_objects.py
+++ b/scripts/detect_god_objects.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Detect god objects inside a directory tree."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from analyzer.detectors.god_object_detector import GodObjectDetector  # noqa: E402
+
+
+def _collect_python_files(target: Path) -> list[Path]:
+    if target.is_file() and target.suffix == ".py":
+        return [target]
+    return sorted(target.rglob("*.py"))
+
+
+def _analyze_file(file_path: Path) -> list:
+    source = file_path.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    tree = ast.parse(source, filename=str(file_path))
+    detector = GodObjectDetector(str(file_path), lines)
+    return detector.detect_violations(tree)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="God object detector wrapper")
+    parser.add_argument("path", help="Path to analyze for god objects")
+    args = parser.parse_args()
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"[ERROR] Path not found: {target}")
+        return 2
+
+    total_god_objects = 0
+    excessive_methods = 0
+    high_complexity = 0
+
+    for py_file in _collect_python_files(target):
+        try:
+            violations = _analyze_file(py_file)
+        except SyntaxError:
+            continue
+
+        for violation in violations:
+            total_god_objects += 1
+            method_count = violation.context.get("method_count") if violation.context else None
+            loc = violation.context.get("estimated_loc") if violation.context else None
+            print(
+                f"GOD OBJECT: {py_file.name}:{violation.line_number} "
+                f"-> {violation.description} ({method_count} methods, ~{loc} LOC)"
+            )
+            if method_count and method_count >= GodObjectDetector.DEFAULT_METHOD_THRESHOLD:
+                excessive_methods += 1
+            if loc and loc >= GodObjectDetector.DEFAULT_LOC_THRESHOLD:
+                high_complexity += 1
+
+    print("=" * 40)
+    print(f"God objects detected: {total_god_objects}")
+    print(f"High-complexity classes flagged: {high_complexity}")
+    print(f"Excessive methods warnings: {excessive_methods}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_clarity001.py
+++ b/scripts/run_clarity001.py
@@ -1,14 +1,158 @@
 #!/usr/bin/env python3
-"""Wrapper for Clarity Linter - delegates to run_week3_clarity_scan.py"""
+"""Lightweight clarity analyzer for thin helpers and call chains."""
 
-import sys
-import subprocess
+from __future__ import annotations
+
+import argparse
+import ast
 from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+class ClarityIssue:
+    def __init__(self, issue_type: str, message: str, file_path: Path, line_number: int):
+        self.issue_type = issue_type
+        self.message = message
+        self.file_path = file_path
+        self.line_number = line_number
+
+    def __str__(self) -> str:  # pragma: no cover - for pretty printing only
+        return f"{self.issue_type}: {self.message} ({self.file_path}:{self.line_number})"
+
+
+def _gather_python_files(target: Path) -> List[Path]:
+    if target.is_file() and target.suffix == ".py":
+        return [target]
+    return sorted(target.rglob("*.py"))
+
+
+def _find_thin_helpers(tree: ast.AST, file_path: Path) -> List[ClarityIssue]:
+    issues: List[ClarityIssue] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            body = [stmt for stmt in node.body if not isinstance(stmt, ast.Pass)]
+            if len(body) == 1 and isinstance(body[0], ast.Return):
+                ret_expr = body[0].value
+                if isinstance(ret_expr, (ast.BinOp, ast.Call, ast.Attribute, ast.Name)):
+                    issues.append(
+                        ClarityIssue(
+                            "thin_helper",
+                            f"Thin helper '{node.name}' simply forwards a call or expression",
+                            file_path,
+                            node.lineno,
+                        )
+                    )
+    return issues
+
+
+def _build_call_graph(tree: ast.AST) -> Dict[str, List[str]]:
+    graph: Dict[str, List[str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            callees: List[str] = []
+            for stmt in node.body:
+                if isinstance(stmt, ast.Return) and isinstance(stmt.value, ast.Call):
+                    if isinstance(stmt.value.func, ast.Name):
+                        callees.append(stmt.value.func.id)
+            if callees:
+                graph[node.name] = callees
+    return graph
+
+
+def _longest_chain(graph: Dict[str, List[str]]) -> Tuple[int, List[str]]:
+    longest: Tuple[int, List[str]] = (0, [])
+
+    def dfs(node: str, visited: List[str]):
+        nonlocal longest
+        if node in visited:
+            return
+        path = visited + [node]
+        if len(path) > longest[0]:
+            longest = (len(path), path)
+        for neighbor in graph.get(node, []):
+            dfs(neighbor, path)
+
+    for start in graph:
+        dfs(start, [])
+    return longest
+
+
+def _find_call_chain_issues(tree: ast.AST, file_path: Path) -> List[ClarityIssue]:
+    graph = _build_call_graph(tree)
+    length, path = _longest_chain(graph)
+    if length >= 5:
+        return [
+            ClarityIssue(
+                "call_chain",
+                f"Deep call chain detected ({length} levels): {' -> '.join(path)}",
+                file_path,
+                1,
+            )
+        ]
+    return []
+
+
+def _find_cognitive_load(tree: ast.AST, file_path: Path) -> List[ClarityIssue]:
+    issues: List[ClarityIssue] = []
+
+    def _depth(node: ast.AST, current_depth: int = 0) -> int:
+        depth = current_depth + 1 if isinstance(node, (ast.If, ast.For, ast.While, ast.With)) else current_depth
+        max_depth = depth
+        for child in ast.iter_child_nodes(node):
+            max_depth = max(max_depth, _depth(child, depth))
+        return max_depth
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            depth = _depth(node)
+            if depth >= 6:
+                issues.append(
+                    ClarityIssue(
+                        "cognitive_load",
+                        f"Function '{node.name}' has high cognitive load (nesting depth {depth})",
+                        file_path,
+                        node.lineno,
+                    )
+                )
+    return issues
+
+
+def analyze_path(target: Path) -> List[ClarityIssue]:
+    issues: List[ClarityIssue] = []
+    for py_file in _gather_python_files(target):
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(py_file))
+        issues.extend(_find_thin_helpers(tree, py_file))
+        issues.extend(_find_call_chain_issues(tree, py_file))
+        issues.extend(_find_cognitive_load(tree, py_file))
+    return issues
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run clarity heuristics")
+    parser.add_argument("path", help="Path to analyze")
+    args = parser.parse_args()
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"[ERROR] Path not found: {target}")
+        return 2
+
+    issues = analyze_path(target)
+    thin_helpers = [issue for issue in issues if issue.issue_type == "thin_helper"]
+    call_chains = [issue for issue in issues if issue.issue_type == "call_chain"]
+    cognitive = [issue for issue in issues if issue.issue_type == "cognitive_load"]
+
+    print("Clarity Analyzer Results")
+    print("=" * 40)
+    for issue in issues:
+        print(f"{issue.issue_type.upper()}: {issue.message} ({issue.file_path}:{issue.line_number})")
+    print("-" * 40)
+    print(f"Thin helpers detected: {len(thin_helpers)}")
+    print(f"Call chain depth alerts: {len(call_chains)}")
+    print(f"Cognitive load warnings: {len(cognitive)}")
+    return 0
+
 
 if __name__ == "__main__":
-    # Delegate to actual clarity scanner
-    script_path = Path(__file__).parent / "run_week3_clarity_scan.py"
-
-    # Pass through all arguments
-    result = subprocess.run([sys.executable, str(script_path)] + sys.argv[1:])
-    sys.exit(result.returncode)
+    raise SystemExit(main())

--- a/scripts/run_enterprise_pipeline.py
+++ b/scripts/run_enterprise_pipeline.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Execute the Unified Quality Gate pipeline and emit structured output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from analyzer.quality_gates.unified_quality_gate import UnifiedQualityGate  # noqa: E402
+
+
+def _summarize(results) -> dict:
+    analyzer_counts = {}
+    for violation in results.violations:
+        source = violation.source_analyzer or "unknown"
+        analyzer_counts[source] = analyzer_counts.get(source, 0) + 1
+
+    analyzers = [
+        {"name": name, "violations": count}
+        for name, count in sorted(analyzer_counts.items())
+    ]
+
+    return {
+        "total_violations": len(results.violations),
+        "files_analyzed": results.metrics.get("files_affected", 0),
+        "scores": {
+            "clarity": results.clarity_score,
+            "connascence": results.connascence_score,
+            "nasa": results.nasa_compliance_score,
+            "overall": results.overall_score,
+        },
+        "analyzers": analyzers,
+        "metadata": results.metadata,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Unified enterprise pipeline runner")
+    parser.add_argument("path", help="Path to analyze")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--config", help="Optional quality gate config file")
+    args = parser.parse_args()
+
+    target = Path(args.path).resolve()
+    if not target.exists():
+        print(f"[ERROR] Path not found: {target}")
+        return 2
+
+    gate = UnifiedQualityGate(config_path=args.config)
+    results = gate.analyze_project(str(target))
+    summary = _summarize(results)
+
+    if args.format == "json":
+        print(json.dumps(summary, indent=2))
+    else:
+        print("Enterprise Pipeline Results")
+        print("=" * 40)
+        for analyzer in summary["analyzers"]:
+            print(f"{analyzer['name']}: {analyzer['violations']} violations")
+        print("-" * 40)
+        print(f"Total violations: {summary['total_violations']}")
+        print(f"Quality scores: {summary['scores']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_all_analyzers_comprehensive.py
+++ b/scripts/verify_all_analyzers_comprehensive.py
@@ -16,10 +16,14 @@ Analyzers Tested:
 from datetime import datetime
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import traceback
 from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = Path(__file__).resolve().parent
 
 
 # ANSI color codes for output
@@ -135,7 +139,7 @@ class ClarityAnalyzerTest(AnalyzerTest):
 
     def run(self, test_dir: str) -> bool:
         """Run clarity analyzer test"""
-        script_path = Path(test_dir).parent / "scripts" / "run_clarity001.py"
+        script_path = SCRIPTS_DIR / "run_clarity001.py"
 
         if not script_path.exists():
             self.errors.append(f"Script not found: {script_path}")
@@ -264,9 +268,9 @@ class ConnascenceAnalyzerTest(AnalyzerTest):
         try:
             # Find connascence analyzer script
             possible_paths = [
-                Path(test_dir).parent / "scripts" / "analyze_connascence.py",
-                Path(test_dir).parent / "analyzer" / "connascence_analyzer.py",
-                Path(test_dir).parent / "src" / "connascence_analyzer.py"
+                SCRIPTS_DIR / "analyze_connascence.py",
+                REPO_ROOT / "analyzer" / "connascence_analyzer.py",
+                REPO_ROOT / "src" / "connascence_analyzer.py"
             ]
 
             script_path = None
@@ -318,7 +322,7 @@ class GodObjectDetectionTest(AnalyzerTest):
 
     def run(self, test_dir: str) -> bool:
         """Run god object detection test"""
-        script_path = Path(test_dir).parent / "scripts" / "detect_god_objects.py"
+        script_path = SCRIPTS_DIR / "detect_god_objects.py"
 
         if not script_path.exists():
             # Try alternative location
@@ -373,7 +377,7 @@ class MECEAnalyzerTest(AnalyzerTest):
 
     def run(self, test_dir: str) -> bool:
         """Run MECE analyzer test"""
-        script_path = Path(test_dir).parent / "scripts" / "analyze_mece.py"
+        script_path = SCRIPTS_DIR / "analyze_mece.py"
 
         if not script_path.exists():
             # Try alternative locations
@@ -435,7 +439,7 @@ class SixSigmaAnalyzerTest(AnalyzerTest):
 
     def run(self, test_dir: str) -> bool:
         """Run Six Sigma analyzer test"""
-        script_path = Path(test_dir).parent / "scripts" / "analyze_six_sigma.py"
+        script_path = SCRIPTS_DIR / "analyze_six_sigma.py"
 
         if not script_path.exists():
             self.errors.append("Six Sigma analyzer script not found")
@@ -486,7 +490,7 @@ class NASASafetyAnalyzerTest(AnalyzerTest):
 
     def run(self, test_dir: str) -> bool:
         """Run NASA safety analyzer test"""
-        script_path = Path(test_dir).parent / "scripts" / "analyze_nasa_safety.py"
+        script_path = SCRIPTS_DIR / "analyze_nasa_safety.py"
 
         if not script_path.exists():
             self.errors.append("NASA safety analyzer script not found")
@@ -543,7 +547,7 @@ class EnterpriseIntegrationTest(AnalyzerTest):
 
     def run(self, test_dir: str) -> bool:
         """Run enterprise integration test"""
-        script_path = Path(test_dir).parent / "scripts" / "run_enterprise_pipeline.py"
+        script_path = SCRIPTS_DIR / "run_enterprise_pipeline.py"
 
         if not script_path.exists():
             # Try alternative
@@ -622,7 +626,9 @@ def create_test_files(test_dir: Path):
 
     print_info(f"Creating test files in {test_dir}")
 
-    # Create test directory
+    # Reset test directory each run to avoid stale artifacts
+    if test_dir.exists():
+        shutil.rmtree(test_dir)
     test_dir.mkdir(parents=True, exist_ok=True)
 
     # Test file 1: Clarity violations (thin helpers, call chains)
@@ -1033,10 +1039,10 @@ def main():
 
     print_section("COMPREHENSIVE ANALYZER VERIFICATION")
 
-    # Setup paths
-    base_dir = Path("/c/Users/17175/Desktop/connascence")
-    test_dir = base_dir / "test_files"
-    scripts_dir = base_dir / "scripts"
+    # Setup paths dynamically relative to repository
+    base_dir = REPO_ROOT
+    test_dir = base_dir / "analysis" / "test_files"
+    scripts_dir = SCRIPTS_DIR
 
     print_info(f"Base directory: {base_dir}")
     print_info(f"Test directory: {test_dir}")


### PR DESCRIPTION
## Summary
- add lightweight CLI wrappers for connascence, MECE, NASA safety, Six Sigma, god-object, clarity, and enterprise pipeline analyzers so that each component can be invoked directly
- enhance the comprehensive analyzer verification script to use the new tooling, reset its sandbox inside the repo, and report dynamically generated results

## Testing
- `python scripts/verify_all_analyzers_comprehensive.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919122e7758832c885d20efb36e7a47)