### PR TITLE
Implement concrete CLI handlers with improved output formatting

### DIFF
--- a/interfaces/cli/connascence.py
+++ b/interfaces/cli/connascence.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import subprocess
 import sys
 import time
-from typing import Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 # License validation availability flag
 LICENSE_VALIDATION_AVAILABLE = False
@@ -58,6 +58,11 @@ except ImportError:
     PolicyManager = None
 
 try:
+    from policy.baselines import BaselineManager
+except ImportError:
+    BaselineManager = None
+
+try:
     from analyzer.unified_analyzer import ErrorHandler, StandardError
 except ImportError:
     # Fallback for environments where unified analyzer isn't available
@@ -79,6 +84,347 @@ except ImportError:
         def handle_exception(self, e, context=None):
             return StandardError(code=5001, message=str(e), context=context or {})
 
+try:
+    from autofix.core import AutofixConfig, AutofixEngine
+    AUTOFIX_AVAILABLE = True
+except ImportError:
+    AutofixConfig = None
+    AutofixEngine = None
+    AUTOFIX_AVAILABLE = False
+
+
+SEVERITY_ORDER = ["critical", "high", "medium", "low", "info"]
+SEVERITY_RANK = {level: idx for idx, level in enumerate(SEVERITY_ORDER)}
+SEVERITY_ALIASES = {
+    "catastrophic": "critical",
+    "critical": "critical",
+    "major": "high",
+    "significant": "high",
+    "high": "high",
+    "error": "high",
+    "moderate": "medium",
+    "medium": "medium",
+    "warning": "medium",
+    "minor": "low",
+    "trivial": "low",
+    "low": "low",
+    "info": "info",
+    "informational": "info",
+    "advisory": "info",
+    "notice": "info",
+    "note": "info",
+}
+
+
+class BaseCommandHandler:
+    """Base class for CLI command handlers."""
+
+    def __init__(self, cli: "ConnascenceCLI"):
+        self.cli = cli
+
+
+class ScanCommandHandler(BaseCommandHandler):
+    """Handler for the legacy scan command."""
+
+    def handle(self, args: argparse.Namespace) -> int:
+        if not self.cli._require_analyzer():
+            return ExitCode.RUNTIME_ERROR
+
+        paths = self._collect_paths(args)
+        if not self.cli._validate_paths(paths):
+            return ExitCode.CONFIGURATION_ERROR
+
+        try:
+            min_severity = self.cli._resolve_min_severity(getattr(args, "severity", None))
+        except ValueError:
+            return ExitCode.CONFIGURATION_ERROR
+
+        violation_map, files_analyzed, analysis_time = self.cli._run_analysis_for_paths(
+            paths,
+            getattr(args, "policy", "service-defaults"),
+            getattr(args, "exclude", None),
+        )
+
+        findings = self.cli._flatten_violation_map(violation_map, min_severity)
+        payload = self.cli._format_analysis_result(
+            findings,
+            files_analyzed=files_analyzed,
+            profile=getattr(args, "policy", "service-defaults"),
+            target=", ".join(paths),
+            analysis_time=analysis_time,
+        )
+        payload["metadata"] = {
+            "paths": [str(Path(p)) for p in paths],
+            "severity_filter": min_severity,
+            "incremental": getattr(args, "incremental", False),
+            "budget_check": getattr(args, "budget_check", False),
+        }
+
+        self.cli._emit_result(payload, getattr(args, "format", "text"), getattr(args, "output", None))
+        return ExitCode.SUCCESS if not findings else ExitCode.GENERAL_ERROR
+
+    def _collect_paths(self, args: argparse.Namespace) -> List[str]:
+        paths: List[str] = []
+        if getattr(args, "path", None):
+            paths.append(args.path)
+        extra_paths = getattr(args, "paths", None)
+        if extra_paths:
+            paths.extend(extra_paths)
+        if not paths:
+            paths = ["."]
+        return paths
+
+
+class ScanDiffCommandHandler(BaseCommandHandler):
+    """Handler for scan-diff command leveraging git history."""
+
+    def handle(self, args: argparse.Namespace) -> int:
+        if not self.cli._require_analyzer():
+            return ExitCode.RUNTIME_ERROR
+
+        base_ref = getattr(args, "base", "HEAD~1")
+        head_ref = getattr(args, "head", "HEAD")
+
+        try:
+            min_severity = self.cli._resolve_min_severity(getattr(args, "severity", None))
+        except ValueError:
+            return ExitCode.CONFIGURATION_ERROR
+
+        changed_files, exit_code = self._collect_changed_files(base_ref, head_ref)
+        if exit_code is not None:
+            return exit_code
+
+        if not changed_files:
+            print("No Python files changed in diff", file=sys.stderr)
+            return ExitCode.SUCCESS
+
+        violation_map, files_analyzed, analysis_time = self.cli._run_analysis_for_files(
+            changed_files,
+            getattr(args, "policy", "service-defaults"),
+        )
+
+        findings = self.cli._flatten_violation_map(violation_map, min_severity)
+        payload = self.cli._format_analysis_result(
+            findings,
+            files_analyzed=files_analyzed,
+            profile=getattr(args, "policy", "service-defaults"),
+            target=f"diff {base_ref}..{head_ref}",
+            analysis_time=analysis_time,
+        )
+        payload["metadata"] = {
+            "base": base_ref,
+            "head": head_ref,
+            "changed_files": len(changed_files),
+            "severity_filter": min_severity,
+        }
+
+        self.cli._emit_result(payload, getattr(args, "format", "text"), getattr(args, "output", None))
+        return ExitCode.SUCCESS if not findings else ExitCode.GENERAL_ERROR
+
+    def _collect_changed_files(self, base_ref: str, head_ref: str) -> Tuple[List[str], Optional[int]]:
+        cmd = ["git", "diff", "--name-only", base_ref, head_ref]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            print(f"git diff failed: {result.stderr.strip()}", file=sys.stderr)
+            return [], ExitCode.RUNTIME_ERROR
+
+        files = [line.strip() for line in result.stdout.splitlines() if line.strip().endswith(".py")]
+        existing = [f for f in files if Path(f).exists()]
+        return existing, None
+
+
+class BaselineCommandHandler(BaseCommandHandler):
+    """Handler for baseline subcommands."""
+
+    def __init__(self, cli: "ConnascenceCLI"):
+        super().__init__(cli)
+        self.manager = BaselineManager() if BaselineManager else None
+
+    def handle(self, args: argparse.Namespace) -> int:
+        if self.manager is None:
+            print("Baseline manager is not available in this environment", file=sys.stderr)
+            return ExitCode.RUNTIME_ERROR
+
+        command = getattr(args, "baseline_command", None)
+        if command in {"snapshot", "create", "update"}:
+            set_active = command in {"create", "update"}
+            return self._create_snapshot(args, set_active=set_active)
+        if command == "status":
+            return self._status()
+
+        print("Unknown or missing baseline subcommand", file=sys.stderr)
+        return ExitCode.INVALID_ARGUMENTS
+
+    def _create_snapshot(self, args: argparse.Namespace, set_active: bool = False) -> int:
+        if not self.cli._require_analyzer():
+            return ExitCode.RUNTIME_ERROR
+        profile = "service-defaults"
+        violation_map, _, analysis_time = self.cli._run_analysis_for_paths(["."], profile)
+        violations = [v for file_list in violation_map.values() for v in file_list]
+        message = getattr(args, "message", "Baseline snapshot")
+        baseline_id = self.manager.create_baseline(violations, description=message)
+        if set_active:
+            self.manager.active_baseline = baseline_id
+
+        print(
+            f"Baseline {baseline_id} created with {len(violations)} violations in {analysis_time:.2f}s"
+        )
+        return ExitCode.SUCCESS
+
+    def _status(self) -> int:
+        baselines = self.manager.list_baselines()
+        if not baselines:
+            print("No baselines recorded yet")
+            return ExitCode.SUCCESS
+
+        print("Baseline history:")
+        for baseline in baselines:
+            created = baseline.get("created_at", "unknown time")
+            description = baseline.get("description", "(no description)")
+            count = baseline.get("violation_count", 0)
+            print(f"- {baseline['id']}: {description} ({count} violations, created {created})")
+        return ExitCode.SUCCESS
+
+
+class AutofixCommandHandler(BaseCommandHandler):
+    """Handler for autofix operations."""
+
+    def handle(self, args: argparse.Namespace) -> int:
+        if not AUTOFIX_AVAILABLE or AutofixEngine is None:
+            print("Autofix engine is not available in this build", file=sys.stderr)
+            return ExitCode.RUNTIME_ERROR
+
+        if not self.cli._require_analyzer():
+            return ExitCode.RUNTIME_ERROR
+
+        if not getattr(args, "force", False) and not getattr(args, "preview", False):
+            print(
+                "Error: Autofix requires --apply to apply changes or --preview to preview fixes",
+                file=sys.stderr,
+            )
+            return ExitCode.INVALID_ARGUMENTS
+
+        target_path = getattr(args, "path", None) or "."
+        if not Path(target_path).exists():
+            print(f"Path does not exist: {target_path}", file=sys.stderr)
+            return ExitCode.CONFIGURATION_ERROR
+
+        violation_map, _, _ = self.cli._run_analysis_for_paths([target_path], "service-defaults")
+        filtered_map = self._filter_violations(violation_map, args)
+
+        engine = AutofixEngine(AutofixConfig(), dry_run=getattr(args, "dry_run", False))
+        patches = self._generate_patches(engine, filtered_map)
+        patches = self.cli._filter_patches(patches, args)
+        if getattr(args, "safe_only", False):
+            patches = [p for p in patches if getattr(p, "safety_level", "safe") == "safe"]
+
+        if getattr(args, "preview", False):
+            print("Preview mode: showing fixes without applying")
+            for patch in patches:
+                print(f"- {patch.file_path}:{patch.line_range} -> {patch.description} ({patch.confidence:.2f})")
+            print(f"Total patches available: {len(patches)}")
+            return ExitCode.SUCCESS
+
+        result = engine.apply_patches(patches, confidence_threshold=getattr(args, "min_confidence", 0.7))
+        print(
+            f"Applied {getattr(result, 'patches_applied', 0)} patches, "
+            f"skipped {getattr(result, 'patches_skipped', 0)}"
+        )
+        for warning in getattr(result, "warnings", []) or []:
+            print(f"warning: {warning}", file=sys.stderr)
+
+        return ExitCode.SUCCESS
+
+    def _filter_violations(
+        self, violation_map: Dict[str, List[Any]], args: argparse.Namespace
+    ) -> Dict[str, List[Any]]:
+        if not getattr(args, "types", None):
+            return violation_map
+
+        allowed_types: set = set()
+        for violation_type in args.types:
+            lowered = violation_type.lower()
+            allowed_types.add(lowered)
+            allowed_types.add(lowered.replace("connascence_of_", ""))
+        filtered: Dict[str, List[Any]] = {}
+        for file_path, violations in violation_map.items():
+            kept = [
+                v
+                for v in violations
+                if self._match_violation_type(v, allowed_types)
+            ]
+            if kept:
+                filtered[file_path] = kept
+        return filtered
+
+    def _generate_patches(
+        self, engine: AutofixEngine, violation_map: Dict[str, List[Any]]
+    ) -> List[Any]:
+        patches: List[Any] = []
+        for file_path, violations in violation_map.items():
+            self.cli._stream_progress(f"[autofix] analyzing {file_path}")
+            patches.extend(engine.analyze_file(file_path, violations))
+        return patches
+
+    def _match_violation_type(self, violation: Any, allowed_types: set) -> bool:
+        violation_type = getattr(violation, "connascence_type", getattr(violation, "type", ""))
+        normalized = str(violation_type).lower()
+        simplified = normalized.replace("connascence_of_", "")
+        return normalized in allowed_types or simplified in allowed_types
+
+
+class MCPCommandHandler(BaseCommandHandler):
+    """Handler for MCP server lifecycle commands."""
+
+    def handle(self, args: argparse.Namespace) -> int:
+        command = getattr(args, "mcp_command", None)
+        if command == "serve":
+            return self._serve(args)
+        if command == "status":
+            return self._status(args)
+
+        print("Unknown MCP subcommand", file=sys.stderr)
+        return ExitCode.INVALID_ARGUMENTS
+
+    def _serve(self, args: argparse.Namespace) -> int:
+        host = getattr(args, "host", "127.0.0.1")
+        port = getattr(args, "port", 8765)
+        env_args = getattr(args, "env", []) or []
+
+        cmd = [sys.executable, "-m", "mcp.cli", "serve", "--host", host, "--port", str(port)]
+        for env_var in env_args:
+            cmd.extend(["--env", env_var])
+
+        self.cli._stream_progress(f"[mcp] starting server on {host}:{port}")
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+        try:
+            assert process.stdout is not None
+            for line in process.stdout:
+                if not line:
+                    break
+                sys.stdout.write(line)
+                sys.stdout.flush()
+        except KeyboardInterrupt:
+            process.terminate()
+            process.wait(timeout=5)
+            return ExitCode.USER_INTERRUPTED
+
+        return self._coerce_exit_code(process.returncode)
+
+    def _status(self, args: argparse.Namespace) -> int:
+        cmd = [sys.executable, "-m", "mcp.cli", "health-check"]
+        result = subprocess.run(cmd, check=False)
+        return self._coerce_exit_code(result.returncode)
+
+    def _coerce_exit_code(self, value: Optional[int]) -> int:
+        if value is None:
+            return ExitCode.RUNTIME_ERROR
+        try:
+            return ExitCode(value)
+        except ValueError:
+            return ExitCode.RUNTIME_ERROR
+
 
 class MockHandler:
     """Mock handler for commands not yet implemented."""
@@ -94,10 +440,11 @@ class ConnascenceCLI:
         self.errors = []
         self.warnings = []
         # Command handlers
-        self.scan_handler = MockHandler()
-        self.baseline_handler = MockHandler()
-        self.autofix_handler = MockHandler()
-        self.mcp_handler = MockHandler()
+        self.scan_handler = ScanCommandHandler(self)
+        self.scan_diff_handler = ScanDiffCommandHandler(self)
+        self.baseline_handler = BaselineCommandHandler(self)
+        self.autofix_handler = AutofixCommandHandler(self)
+        self.mcp_handler = MCPCommandHandler(self)
         self.license_validator = None
         self.policy_manager = PolicyManager() if PolicyManager else None
 
@@ -216,6 +563,23 @@ class ConnascenceCLI:
         diff_parser = subparsers.add_parser("scan-diff", help="Scan diff between commits")
         diff_parser.add_argument("--base", type=str, default="HEAD~1", help="Base commit")
         diff_parser.add_argument("--head", type=str, default="HEAD", help="Head commit")
+        diff_parser.add_argument(
+            "--policy",
+            dest="policy",
+            default="service-defaults",
+            help=(
+                "Policy preset to use when analyzing the diff "
+                f"(available: {', '.join(UNIFIED_POLICY_NAMES)})"
+            ),
+        )
+        diff_parser.add_argument(
+            "--format",
+            choices=["text", "json", "markdown", "sarif"],
+            default="text",
+            help="Output format for diff analysis",
+        )
+        diff_parser.add_argument("--output", "-o", type=str, help="Output file path")
+        diff_parser.add_argument("--severity", type=str, help="Minimum severity level to report")
 
         # Baseline command
         baseline_parser = subparsers.add_parser("baseline", help="Manage baseline")
@@ -379,9 +743,9 @@ class ConnascenceCLI:
                     "[deprecated] 'scan' will be removed in a future release. Use 'analyze' or 'analyze-workspace' instead.",
                     file=sys.stderr,
                 )
-                return self._handle_scan(parsed_args)
+                return self.scan_handler.handle(parsed_args)
             elif parsed_args.command == "scan-diff":
-                return self._handle_scan_diff(parsed_args)
+                return self.scan_diff_handler.handle(parsed_args)
             elif parsed_args.command == "analyze":
                 return self._handle_analyze(parsed_args)
             elif parsed_args.command == "analyze-workspace":
@@ -391,41 +755,22 @@ class ConnascenceCLI:
             elif parsed_args.command == "suggest-refactoring":
                 return self._handle_suggest_refactoring(parsed_args)
             elif parsed_args.command == "baseline":
-                return self._handle_baseline(parsed_args)
+                return self.baseline_handler.handle(parsed_args)
             elif parsed_args.command == "autofix":
-                return self._handle_autofix(parsed_args)
+                return self.autofix_handler.handle(parsed_args)
             elif parsed_args.command == "mcp":
-                return self._handle_mcp(parsed_args)
+                return self.mcp_handler.handle(parsed_args)
             elif parsed_args.command in ["explain", "license"]:
                 # These commands just return success for now
                 return ExitCode.SUCCESS
         except KeyboardInterrupt:
-            raise  # Re-raise to be handled by main()
+            print("\nAnalysis interrupted by user", file=sys.stderr)
+            return ExitCode.USER_INTERRUPTED
         except Exception as e:
             print(f"Command execution failed: {e}", file=sys.stderr)
             import traceback
             traceback.print_exc()
             return ExitCode.RUNTIME_ERROR
-
-        # Placeholder analysis result (for backward compatibility)
-        result = {
-            "analysis_complete": True,
-            "paths_analyzed": getattr(parsed_args, "paths", []),
-            "violations_found": 0,
-            "status": "completed",
-            "policy_used": getattr(parsed_args, "policy", "standard"),
-            "policy_system": "unified_v2.0",
-        }
-
-        if hasattr(parsed_args, "output") and parsed_args.output:
-            import json
-
-            with open(parsed_args.output, "w") as f:
-                json.dump(result, f, indent=2)
-            print(f"Results written to {parsed_args.output}")
-        else:
-            print("Analysis completed successfully")
-
         return ExitCode.SUCCESS
 
     def _handle_cli_error(self, error: StandardError):
@@ -481,192 +826,121 @@ class ConnascenceCLI:
 
         return True
 
-    def _handle_scan(self, args: argparse.Namespace) -> int:
-        """Handle scan command execution."""
-        import json
-        from pathlib import Path
+    def _stream_progress(self, message: str) -> None:
+        """Emit progress information for streaming integrations."""
+        print(message, file=sys.stderr)
 
-        # Normalize path handling - support both single path and paths list
-        paths_to_scan = []
-        if hasattr(args, 'path') and args.path:
-            paths_to_scan.append(args.path)
-        if hasattr(args, 'paths') and args.paths:
-            paths_to_scan.extend(args.paths)
+    def _resolve_min_severity(self, severity: Optional[str]) -> Optional[str]:
+        """Validate and normalize severity filters."""
+        if not severity:
+            return None
 
-        # If no paths provided, use current directory
-        if not paths_to_scan:
-            paths_to_scan = ['.']
+        normalized = severity.strip().lower()
+        mapped = SEVERITY_ALIASES.get(normalized, normalized)
+        if mapped in SEVERITY_RANK:
+            return mapped
 
-        # Validate format argument (already validated by argparse choices)
-        # Validate severity argument if provided
-        if hasattr(args, 'severity') and args.severity:
-            valid_severities = list(SEVERITY_LEVELS.values())
-            if args.severity.upper() not in valid_severities:
-                print(f"Error: Invalid severity level '{args.severity}'. Valid values: {', '.join(valid_severities)}", file=sys.stderr)
-                return EXIT_CONFIGURATION_ERROR
+        error = self.error_handler.create_error(
+            "CLI_ARGUMENT_INVALID",
+            f"Unknown severity level '{severity}'",
+            ERROR_SEVERITY["HIGH"],
+            {"severity": severity, "allowed": list(SEVERITY_RANK.keys())},
+        )
+        self._handle_cli_error(error)
+        raise ValueError(severity)
 
-        # Validate paths exist
-        for path in paths_to_scan:
-            if not Path(path).exists() and path != '.':
-                print(f"Error: Path does not exist: {path}", file=sys.stderr)
-                return EXIT_CONFIGURATION_ERROR
+    def _run_analysis_for_paths(
+        self,
+        paths: Iterable[str],
+        profile: str,
+        exclude: Optional[str] = None,
+    ) -> Tuple[Dict[str, List[Any]], int, float]:
+        files = list(self._iter_source_files(paths, exclude))
+        return self._run_analysis_for_files(files, profile)
 
-        # Try to use analyzer if available (for test compatibility)
-        violations = []
-        try:
-            # Check if analyzer is available at module level
-            if not ANALYZER_AVAILABLE or ConnascenceASTAnalyzer is None:
-                raise ImportError("Analyzer not available")
+    def _run_analysis_for_files(
+        self,
+        files: Iterable[Path],
+        profile: str,
+    ) -> Tuple[Dict[str, List[Any]], int, float]:
+        thresholds = self._get_threshold_config(profile)
+        analyzer = ConnascenceASTAnalyzer(thresholds=thresholds)
+        violation_map: Dict[str, List[Any]] = {}
+        start = time.time()
+        files_analyzed = 0
 
-            # Real analyzer uses thresholds, not policy_preset
-            analyzer = ConnascenceASTAnalyzer(thresholds=ThresholdConfig())
+        for file_path in files:
+            path_obj = Path(file_path)
+            if not path_obj.exists():
+                continue
+            self._stream_progress(f"[scan] Analyzing {path_obj}")
+            try:
+                violations = analyzer.analyze_file(path_obj)
+            except Exception as exc:  # pragma: no cover - analyzer failures are rare
+                error = self.error_handler.create_error(
+                    "ANALYSIS_FAILED",
+                    f"Failed to analyze {path_obj}: {exc}",
+                    ERROR_SEVERITY["MEDIUM"],
+                    {"path": str(path_obj)},
+                )
+                self._handle_cli_error(error)
+                continue
 
-            # Analyze each path
-            for path in paths_to_scan:
-                path_obj = Path(path)
+            violation_map[str(path_obj)] = violations
+            files_analyzed += 1
 
-                # Check if path is a file or directory
-                if path_obj.is_file():
-                    # Single file analysis
-                    result = analyzer.analyze_file(path_obj)
-                    violations.extend(result)
-                else:
-                    # Directory analysis
-                    result = analyzer.analyze_directory(path_obj)
-                    # Extract violations from AnalysisResult object
-                    if hasattr(result, 'violations'):
-                        violations.extend(result.violations)
-                    else:
-                        # Fallback for list return type
-                        violations.extend(result)
-        except Exception as e:
-            # If analyzer fails, log error and return empty
-            print(f"Error: Analysis failed: {type(e).__name__}: {e}", file=sys.stderr)
-            violations = []
+        analysis_time = time.time() - start
+        return violation_map, files_analyzed, analysis_time
 
-        # Generate output based on format
-        if args.format == 'json':
-            # Build result object
-            result = {
-                'violations': [v.to_dict() if hasattr(v, 'to_dict') else str(v) for v in violations],
-                'total_files_analyzed': len(paths_to_scan),
-                'paths': paths_to_scan,
-                'policy': args.policy
-            }
+    def _iter_source_files(self, paths: Iterable[str], exclude: Optional[str] = None) -> Iterable[Path]:
+        seen = set()
+        for raw_path in paths:
+            path_obj = Path(raw_path)
+            if not path_obj.exists():
+                continue
 
-            output_str = json.dumps(result, indent=2)
+            if path_obj.is_file():
+                if self._is_file_excluded(path_obj, exclude):
+                    continue
+                real = path_obj.resolve()
+                if real not in seen:
+                    seen.add(real)
+                    yield path_obj
+                continue
 
-            # Write to output file if specified
-            if hasattr(args, 'output') and args.output:
-                output_path = Path(args.output)
-                with open(output_path, 'w') as f:
-                    f.write(output_str)
-                print(f"Results written to {output_path}")
-            else:
-                print(output_str)
-        else:
-            print(f"Scanned {len(paths_to_scan)} path(s)")
-            print(f"Found {len(violations)} violation(s)")
+            for file_path in path_obj.rglob("*.py"):
+                if self._is_file_excluded(file_path, exclude):
+                    continue
+                real = file_path.resolve()
+                if real in seen:
+                    continue
+                seen.add(real)
+                yield file_path
 
-        # Return appropriate exit code
-        exit_code = 1 if violations else 0
-        return exit_code
+    def _is_file_excluded(self, file_path: Path, exclude: Optional[str]) -> bool:
+        if not exclude:
+            return False
+        return exclude in str(file_path)
 
-    def _handle_scan_diff(self, args: argparse.Namespace) -> int:
-        """Handle scan-diff command execution."""
-        # Mock implementation
-        print(f"Scanning diff from {args.base} to {getattr(args, 'head', 'HEAD')}")
-        return 0
+    def _flatten_violation_map(
+        self, violation_map: Dict[str, List[Any]], min_severity: Optional[str]
+    ) -> List[Any]:
+        findings: List[Any] = []
+        for violations in violation_map.values():
+            for violation in violations:
+                if self._should_include_violation(violation, min_severity):
+                    findings.append(violation)
+        return findings
 
-    def _handle_baseline(self, args: argparse.Namespace) -> int:
-        """Handle baseline command execution."""
-        command = getattr(args, 'baseline_command', None)
-        if command == 'snapshot':
-            message = getattr(args, 'message', 'Baseline snapshot')
-            print(f"Creating baseline snapshot: {message}")
-        elif command == 'status':
-            print("Baseline status: no baseline set")
-        elif command in ['create', 'update']:
-            print(f"Baseline {command} completed")
-        return 0
+    def _should_include_violation(self, violation: Any, min_severity: Optional[str]) -> bool:
+        if min_severity is None:
+            return True
 
-    def _handle_autofix(self, args: argparse.Namespace) -> int:
-        """Handle autofix command execution."""
-        # Check if force/apply flag is set
-        if not hasattr(args, 'force') or not args.force:
-            if not hasattr(args, 'preview') or not args.preview:
-                print("Error: Autofix requires --apply flag to confirm changes (or --preview to preview without applying)", file=sys.stderr)
-                return 1
+        severity = str(getattr(violation, "severity", "info")).lower()
+        violation_rank = SEVERITY_RANK.get(severity, len(SEVERITY_RANK))
+        threshold = SEVERITY_RANK[min_severity]
+        return violation_rank <= threshold
 
-        # Load violations to fix
-        violations = self._load_or_scan_violations(args)
-
-        # Group violations by file
-        violations_by_file = self._group_violations_by_file(violations)
-
-        # Try to use autofix engine if available
-        try:
-            from cli.connascence import AutofixEngine
-            engine = AutofixEngine()
-
-            all_patches = []
-            for file_path, file_violations in violations_by_file.items():
-                patches = engine.analyze_file(file_path)
-                all_patches.extend(patches)
-
-            # Filter patches based on confidence and other criteria
-            filtered_patches = self._filter_patches(all_patches, args)
-
-        except Exception:
-            filtered_patches = []
-
-        # Preview mode
-        if hasattr(args, 'preview') and args.preview:
-            print("Preview mode: showing fixes without applying")
-            print(f"Found {len(filtered_patches)} fix(es)")
-            return 0
-
-        # Apply mode
-        print("Applying fixes...")
-        print(f"Applied {len(filtered_patches)} fix(es)")
-        return 0
-
-    def _handle_mcp(self, args: argparse.Namespace) -> int:
-        """Handle MCP command execution."""
-        command = getattr(args, 'mcp_command', None)
-        if command == 'serve':
-            host = getattr(args, 'host', '127.0.0.1')
-            port = getattr(args, 'port', 8765)
-            env_args = getattr(args, 'env', []) or []
-
-            cmd = [sys.executable, '-m', 'mcp.cli', 'serve', '--host', host, '--port', str(port)]
-            for env_var in env_args:
-                cmd.extend(['--env', env_var])
-
-            result = subprocess.run(cmd, check=False)
-            return result.returncode
-
-        if command == 'status':
-            cmd = [sys.executable, '-m', 'mcp.cli', 'health-check']
-            result = subprocess.run(cmd, check=False)
-            return result.returncode
-
-        print("Unknown MCP subcommand", file=sys.stderr)
-        return ExitCode.ERROR
-
-    def _load_or_scan_violations(self, args: argparse.Namespace = None):
-        """Load violations from scan or existing results."""
-        # Mock implementation - returns empty list
-        return []
-
-    def _group_violations_by_file(self, violations):
-        """Group violations by file path."""
-        from collections import defaultdict
-        grouped = defaultdict(list)
-        for violation in violations:
-            file_path = getattr(violation, 'file_path', 'unknown')
-            grouped[file_path].append(violation)
-        return dict(grouped)
 
     def _filter_patches(self, patches, args):
         """Filter patches based on confidence and other criteria."""
@@ -988,6 +1262,17 @@ class ConnascenceCLI:
                 print(serialized)
             return
 
+        if fmt == "markdown":
+            content = self._render_markdown(payload)
+            self._write_output(content, output_path)
+            return
+
+        if fmt == "sarif":
+            sarif_payload = self._build_sarif(payload)
+            content = json.dumps(sarif_payload, indent=2)
+            self._write_output(content, output_path)
+            return
+
         self._print_text_summary(payload)
         if output_path:
             Path(output_path).write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -1028,6 +1313,99 @@ class ConnascenceCLI:
             return
 
         print(json.dumps(payload, indent=2))
+
+    def _write_output(self, content: str, output_path: Optional[str]) -> None:
+        if output_path:
+            Path(output_path).write_text(content, encoding="utf-8")
+            print(f"Results written to {output_path}")
+        else:
+            print(content)
+
+    def _render_markdown(self, payload: Dict[str, object]) -> str:
+        lines = ["# Connascence Analysis Report", ""]
+        target = payload.get("target", "input")
+        profile = payload.get("profile", "service-defaults")
+        lines.append(f"- **Target**: `{target}`")
+        lines.append(f"- **Profile**: `{profile}`")
+        lines.append(f"- **Quality Score**: {payload.get('quality_score', 'n/a')}")
+        summary = payload.get("summary", {})
+        lines.append(
+            f"- **Findings**: {summary.get('totalIssues', 0)} (critical={summary.get('issuesBySeverity', {}).get('critical', 0)}, "
+            f"major={summary.get('issuesBySeverity', {}).get('major', 0)}, "
+            f"minor={summary.get('issuesBySeverity', {}).get('minor', 0)}, "
+            f"info={summary.get('issuesBySeverity', {}).get('info', 0)})"
+        )
+        lines.append("")
+
+        findings = payload.get("findings", [])
+        if not findings:
+            lines.append("_No findings were reported for the selected severity threshold._")
+            return "\n".join(lines)
+
+        lines.append("| Severity | Rule | Message | Location |")
+        lines.append("| --- | --- | --- | --- |")
+        for finding in findings:
+            severity = finding.get("severity", "info")
+            rule = finding.get("type", finding.get("id", "connascence"))
+            message = str(finding.get("message", "")).replace("|", "\\|")
+            location = f"{finding.get('file', '')}:{finding.get('line', 0)}"
+            lines.append(f"| {severity} | {rule} | {message} | {location} |")
+
+        return "\n".join(lines)
+
+    def _build_sarif(self, payload: Dict[str, object]) -> Dict[str, Any]:
+        findings = payload.get("findings", [])
+        results = []
+        for finding in findings:
+            level = self._sarif_level(finding.get("severity"))
+            message = finding.get("message", "Connascence issue detected")
+            location = {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": finding.get("file", "")},
+                    "region": {
+                        "startLine": finding.get("line", 1) or 1,
+                        "startColumn": max(1, finding.get("column", 1) or 1),
+                    },
+                }
+            }
+            results.append(
+                {
+                    "ruleId": finding.get("type") or finding.get("id") or "connascence",
+                    "level": level,
+                    "message": {"text": message},
+                    "locations": [location],
+                    "properties": {"suggestion": finding.get("suggestion")},
+                }
+            )
+
+        run = {
+            "tool": {
+                "driver": {
+                    "name": "connascence-cli",
+                    "version": "2.0.0",
+                    "informationUri": "https://github.com/connascence/connascence-safety-analyzer",
+                }
+            },
+            "results": results,
+            "properties": {
+                "profile": payload.get("profile"),
+                "target": payload.get("target"),
+                "summary": payload.get("summary"),
+            },
+        }
+        return {
+            "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [run],
+        }
+
+    def _sarif_level(self, severity: Optional[str]) -> str:
+        normalized = str(severity or "warning").lower()
+        if normalized in {"critical", "high", "major"}:
+            return "error"
+        if normalized in {"medium", "minor"}:
+            return "warning"
+        return "note"
 
 
 def main(args: Optional[List[str]] = None) -> int:


### PR DESCRIPTION
## Summary
- replace the placeholder CLI mock handlers with real scan, scan-diff, baseline, autofix, and MCP command handlers wired into the AST analyzer, baseline manager, and autofix engine
- add shared severity filtering plus text, JSON, Markdown, and SARIF rendering utilities so CLI output matches VS Code and wrapper expectations
- add reusable analysis helpers, streaming progress, and standardized exit codes/error reporting used by the new handlers

## Testing
- `pytest tests/test_exit_codes_unit.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919143de91c832c8fdcd8d5e7facfac)