### PR TITLE
Unify CLI analysis pipeline across MCP and VSCode

### DIFF
--- a/analyzer/cli_entry.py
+++ b/analyzer/cli_entry.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: MIT
+"""Shared entry point for CLI-compatible analyzer workflows.
+
+This module centralizes the logic that powers the `connascence` CLI, MCP server
+handlers, and local API clients.  It ensures that every surface that consumes
+analysis results receives the exact same JSON schema (`findings`, `summary`,
+`quality_score`, etc.) and that safety profiles / threshold handling is kept
+in sync.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import time
+from typing import Dict, Iterable, Iterator, List, Optional
+
+try:  # Import heavy analyzer dependencies lazily to keep tests lightweight
+    from analyzer.ast_engine.core_analyzer import ConnascenceASTAnalyzer
+    from analyzer.thresholds import ThresholdConfig
+except ImportError:  # pragma: no cover - handled at runtime by CLI guards
+    ConnascenceASTAnalyzer = None  # type: ignore[assignment]
+    ThresholdConfig = None  # type: ignore[assignment]
+
+try:
+    from policy.manager import PolicyManager
+except ImportError:  # pragma: no cover - policy manager optional in tests
+    PolicyManager = None  # type: ignore[assignment]
+
+
+DEFAULT_FILE_PATTERNS: tuple[str, ...] = ("*.py",)
+
+
+@dataclass(frozen=True)
+class CliFinding:
+    """Lightweight representation of a normalized finding."""
+
+    id: str
+    type: str
+    severity: str
+    message: str
+    file: str
+    line: int
+    column: int
+    suggestion: Optional[str] = None
+    connascence_type: Optional[str] = None
+
+
+class SharedCLIAnalyzer:
+    """Singleton-friendly helper that powers CLI + MCP workflows."""
+
+    def __init__(self) -> None:
+        self.policy_manager = PolicyManager() if PolicyManager else None
+        self._threshold_cache: Dict[str, ThresholdConfig] = {}
+        self._analyzer_cache: Dict[str, ConnascenceASTAnalyzer] = {}
+
+    # ------------------------------------------------------------------
+    # Public surface consumed by CLI + MCP
+    # ------------------------------------------------------------------
+    def analyze_file(self, target: Path, profile: str) -> Dict[str, object]:
+        analyzer = self._require_analyzer(profile)
+        start = time.time()
+        violations = analyzer.analyze_file(target)
+        payload = self._format_analysis_result(
+            violations,
+            profile=profile,
+            target=str(target),
+            files_analyzed=1,
+            analysis_time=time.time() - start,
+        )
+        return payload
+
+    def analyze_workspace(
+        self,
+        workspace: Path,
+        profile: str,
+        *,
+        patterns: Optional[Iterable[str]] = None,
+        selected_files: Optional[Iterable[Path]] = None,
+    ) -> Dict[str, object]:
+        analyzer = self._require_analyzer(profile)
+        files: Dict[str, Dict[str, object]] = {}
+        total_score = 0.0
+        file_iter = selected_files if selected_files else self._iter_workspace_files(workspace, patterns)
+
+        for file_path in file_iter:
+            start = time.time()
+            violations = analyzer.analyze_file(file_path)
+            file_payload = self._format_analysis_result(
+                violations,
+                profile=profile,
+                target=str(file_path),
+                files_analyzed=1,
+                analysis_time=time.time() - start,
+            )
+            files[str(file_path)] = file_payload
+            total_score += file_payload.get("quality_score", 0.0)  # type: ignore[arg-type]
+
+        analyzed_files = len(files)
+        return {
+            "files": files,
+            "profile": profile,
+            "files_analyzed": analyzed_files,
+            "overall_score": round(total_score / analyzed_files, 2) if analyzed_files else 100.0,
+        }
+
+    def serialize(self, payload: Dict[str, object]) -> str:
+        """Utility used by CLI + MCP to ensure identical JSON serialization."""
+
+        return json.dumps(payload, indent=2, sort_keys=False)
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+    def format_analysis_result(
+        self,
+        violations,
+        *,
+        profile: str,
+        files_analyzed: int,
+        target: Optional[str] = None,
+        analysis_time: Optional[float] = None,
+    ) -> Dict[str, object]:
+        return self._format_analysis_result(
+            violations,
+            profile=profile,
+            files_analyzed=files_analyzed,
+            target=target,
+            analysis_time=analysis_time,
+        )
+
+    def get_threshold_config(self, profile: str) -> ThresholdConfig:
+        if profile in self._threshold_cache:
+            return self._threshold_cache[profile]
+
+        if self.policy_manager:
+            try:
+                threshold = self.policy_manager.get_preset(profile)
+            except ValueError:
+                threshold = ThresholdConfig() if ThresholdConfig else None  # type: ignore[assignment]
+        else:
+            threshold = ThresholdConfig() if ThresholdConfig else None  # type: ignore[assignment]
+
+        if threshold is None or not hasattr(threshold, "min_magic_literal_threshold"):
+            threshold = ThresholdConfig() if ThresholdConfig else None  # type: ignore[assignment]
+
+        if threshold is None:
+            raise RuntimeError("Threshold configuration unavailable")
+
+        self._threshold_cache[profile] = threshold
+        return threshold
+
+    def _require_analyzer(self, profile: str):
+        if ConnascenceASTAnalyzer is None or ThresholdConfig is None:
+            raise RuntimeError("Analyzer components are not available")
+
+        if profile in self._analyzer_cache:
+            return self._analyzer_cache[profile]
+
+        thresholds = self.get_threshold_config(profile)
+        analyzer = ConnascenceASTAnalyzer(thresholds=thresholds)
+        self._analyzer_cache[profile] = analyzer
+        return analyzer
+
+    def _iter_workspace_files(self, workspace: Path, patterns: Optional[Iterable[str]]) -> Iterator[Path]:
+        glob_patterns = list(patterns) if patterns else list(DEFAULT_FILE_PATTERNS)
+        seen = set()
+        for pattern in glob_patterns:
+            for path in workspace.rglob(pattern):
+                if not path.is_file():
+                    continue
+                real_path = path.resolve()
+                if real_path in seen:
+                    continue
+                seen.add(real_path)
+                yield path
+
+    def _format_analysis_result(
+        self,
+        violations,
+        *,
+        profile: str,
+        files_analyzed: int,
+        target: Optional[str] = None,
+        analysis_time: Optional[float] = None,
+    ) -> Dict[str, object]:
+        severity_map = {"critical": "critical", "high": "major", "medium": "minor", "low": "info"}
+        severity_summary = {"critical": 0, "major": 0, "minor": 0, "info": 0}
+        findings: List[Dict[str, object]] = []
+        normalized_violations = list(violations or [])
+
+        for idx, violation in enumerate(normalized_violations):
+            finding = self._convert_violation(violation, idx, target)
+            finding_severity = severity_map.get(str(getattr(violation, "severity", "medium")).lower(), "info")
+            severity_summary[finding_severity] += 1
+            finding["severity"] = finding_severity
+            findings.append(finding)
+
+        total_weight = sum((getattr(v, "weight", 1.0) or 1.0) for v in normalized_violations)
+        quality_score = round(max(0.0, 100.0 - (total_weight * 5.0)), 2)
+        payload: Dict[str, object] = {
+            "target": target,
+            "profile": profile,
+            "quality_score": quality_score,
+            "findings": findings,
+            "summary": {"totalIssues": len(findings), "issuesBySeverity": severity_summary},
+            "files_analyzed": files_analyzed,
+        }
+
+        if analysis_time is not None:
+            payload["analysis_time_ms"] = int(analysis_time * 1000)
+
+        return payload
+
+    def _convert_violation(
+        self,
+        violation,
+        idx: int = 0,
+        default_file: Optional[str] = None,
+    ) -> Dict[str, object]:
+        violation_id = getattr(violation, "id", None) or f"{getattr(violation, 'type', 'violation')}-{idx}"
+        conn_type = getattr(violation, "connascence_type", None) or getattr(violation, "type", "")
+        severity = getattr(violation, "severity", "medium")
+        description = getattr(violation, "description", "") or f"Detected {conn_type or 'connascence'}"
+        recommendation = getattr(violation, "recommendation", "")
+        line_number = getattr(violation, "line_number", 0) or 0
+
+        return {
+            "id": violation_id,
+            "type": conn_type or getattr(violation, "type", "unknown"),
+            "severity": str(severity).lower(),
+            "message": description,
+            "file": getattr(violation, "file_path", "") or default_file,
+            "line": line_number,
+            "column": getattr(violation, "column", 0) or 0,
+            "suggestion": recommendation,
+            "connascence_type": conn_type or getattr(violation, "type", "unknown"),
+        }
+
+
+_SHARED_ANALYZER: Optional[SharedCLIAnalyzer] = None
+
+
+def get_shared_cli_analyzer() -> SharedCLIAnalyzer:
+    """Return a singleton instance that callers can reuse to benefit from caches."""
+
+    global _SHARED_ANALYZER
+    if _SHARED_ANALYZER is None:
+        _SHARED_ANALYZER = SharedCLIAnalyzer()
+    return _SHARED_ANALYZER
+
+
+__all__ = ["CliFinding", "SharedCLIAnalyzer", "DEFAULT_FILE_PATTERNS", "get_shared_cli_analyzer"]

--- a/mcp/analysis_bridge.py
+++ b/mcp/analysis_bridge.py
@@ -4,252 +4,57 @@
 
 from __future__ import annotations
 
-import logging
-import time
-from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, Iterable, List
 
+from analyzer.cli_entry import SharedCLIAnalyzer, get_shared_cli_analyzer
 from fixes.phase0.production_safe_assertions import ProductionAssert
-
-try:  # Import the canonical analyzer pipeline used by the CLI
-    from analyzer.unified_analyzer import UnifiedAnalyzer
-except ImportError:  # pragma: no cover - fallback for stripped test envs
-    UnifiedAnalyzer = None  # type: ignore[assignment]
-
-try:
-    from analyzer.ast_engine.core_analyzer import ConnascenceASTAnalyzer
-except ImportError:  # pragma: no cover - fallback for stripped test envs
-    ConnascenceASTAnalyzer = None  # type: ignore[assignment]
-
-try:
-    from policy.manager import PolicyManager, ThresholdConfig
-except ImportError:  # pragma: no cover - fallback for stripped test envs
-    PolicyManager = None  # type: ignore[assignment]
-    ThresholdConfig = None  # type: ignore[assignment]
-
-logger = logging.getLogger(__name__)
 
 
 class AnalyzerBridge:
     """Bridge that exposes CLI analyzer behaviour to the MCP server."""
 
     def __init__(self):
-        self._analyzer = self._load_analyzer()
-        self.policy_manager = self._load_policy_manager()
+        self._cli_helper: SharedCLIAnalyzer = get_shared_cli_analyzer()
 
-    def analyze_file(self, file_path: str, analysis_type: str = "full") -> Dict[str, Any]:
-        """Run CLI-grade analysis for a single file and normalize output."""
-
+    def analyze_file(self, file_path: str, analysis_type: str = "full") -> Dict[str, object]:
         ProductionAssert.not_none(file_path, "file_path")
-        start_time = time.time()
-        analyzer_raw = self._analyzer.analyze_file(file_path)
-        analyzer_result = self._ensure_result_mapping(analyzer_raw, file_path)
+        profile = self._resolve_profile(analysis_type)
+        payload = self._cli_helper.analyze_file(Path(file_path), profile)
+        payload.setdefault("analysis_type", analysis_type)
+        payload.setdefault("target", str(file_path))
+        return payload
 
-        violations = self._normalize_violations(analyzer_result.get("connascence_violations", []))
-        nasa_violations = self._normalize_violations(analyzer_result.get("nasa_violations", []))
-        severity_counts = self._count_by_severity(violations)
-
-        summary = {
-            "total_violations": len(violations),
-            "by_severity": severity_counts,
-        }
-
-        nasa_score = analyzer_result.get("nasa_compliance_score", 1.0)
-        nasa_compliance = {
-            "score": nasa_score,
-            "violations": nasa_violations,
-            "passing": nasa_score >= 0.8,
-        }
-
-        mece_analysis = {
-            "score": 1.0,
-            "duplications": [],
-            "passing": True,
-        }
-
-        policy_name, policy_thresholds = self._resolve_policy_snapshot(analysis_type)
-        metadata = {
-            "analysis_type": analysis_type,
-            "file_path": str(file_path),
-            "timestamp": time.time(),
-            "policy": policy_name,
-            "policy_thresholds": policy_thresholds,
-        }
-
-        metrics = {
-            "files_analyzed": 1,
-            "analysis_time": time.time() - start_time,
-            "timestamp": metadata["timestamp"],
-        }
-
-        return {
-            "success": True,
-            "file_path": str(file_path),
-            "analysis_type": analysis_type,
-            "violations": violations,
-            "summary": summary,
-            "nasa_compliance": nasa_compliance,
-            "mece_analysis": mece_analysis,
-            "metadata": metadata,
-            "metrics": metrics,
-        }
-
-    def analyze_workspace(self, workspace_path: Path, file_paths: List[Path], analysis_type: str) -> Dict[str, Any]:
-        """Analyze all files collected by the server for the workspace tool."""
-
+    def analyze_workspace(
+        self,
+        workspace_path: Path,
+        file_paths: Iterable[Path],
+        analysis_type: str,
+    ) -> Dict[str, object]:
         ProductionAssert.not_none(workspace_path, "workspace_path")
         ProductionAssert.not_none(file_paths, "file_paths")
+        profile = self._resolve_profile(analysis_type)
+        return self._cli_helper.analyze_workspace(
+            workspace_path,
+            profile,
+            selected_files=list(file_paths),
+        )
 
-        aggregated_results: List[Dict[str, Any]] = []
-        total_violations = 0
-        severity_totals: Dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0}
-        start_time = time.time()
-
-        for file_path in file_paths:
-            file_result = self.analyze_file(str(file_path), analysis_type=analysis_type)
-            aggregated_results.append(file_result)
-            total_violations += len(file_result.get("violations", []))
-            file_severities = file_result.get("summary", {}).get("by_severity", {})
-            for severity, count in file_severities.items():
-                severity_totals[severity] = severity_totals.get(severity, 0) + count
-
-        summary = {
-            "total_files_analyzed": len(file_paths),
-            "total_violations": total_violations,
-            "severity_totals": severity_totals,
-            "analysis_time": time.time() - start_time,
-        }
-
+    def health_snapshot(self) -> Dict[str, object]:
         return {
-            "success": True,
-            "workspace_path": str(workspace_path),
-            "analysis_type": analysis_type,
-            "file_results": aggregated_results,
-            "summary": summary,
+            "analyzer_available": True,
+            "analyzer_type": type(self._cli_helper).__name__,
+            "policy_manager": bool(self._cli_helper.policy_manager),
         }
 
-    def health_snapshot(self) -> Dict[str, Any]:
-        """Return metadata describing the analyzer stack."""
-
-        return {
-            "analyzer_available": self._analyzer is not None,
-            "analyzer_type": type(self._analyzer).__name__ if self._analyzer else "unavailable",
-            "policy_manager": self.policy_manager is not None,
-        }
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _load_analyzer(self):
-        """Mirror the CLI loading order."""
-
-        if UnifiedAnalyzer is not None:
-            try:
-                return UnifiedAnalyzer()
-            except Exception as exc:  # pragma: no cover - only hit when deps missing
-                logger.warning("UnifiedAnalyzer unavailable: %s", exc)
-
-        if ConnascenceASTAnalyzer is not None:
-            try:
-                return ConnascenceASTAnalyzer()
-            except Exception as exc:  # pragma: no cover - only hit when deps missing
-                logger.warning("ConnascenceASTAnalyzer unavailable: %s", exc)
-
-        raise RuntimeError("No analyzer implementation available for MCP server")
-
-    def _load_policy_manager(self):
-        if PolicyManager is None:
-            return None
-        try:
-            return PolicyManager()
-        except Exception as exc:  # pragma: no cover - should not happen in prod envs
-            logger.warning("PolicyManager unavailable: %s", exc)
-            return None
-
-    def _normalize_violations(self, violations: List[Any]) -> List[Dict[str, Any]]:
-        normalized: List[Dict[str, Any]] = []
-        for violation in violations:
-            if hasattr(violation, "to_dict"):
-                data = violation.to_dict()  # type: ignore[assignment]
-            elif isinstance(violation, dict):
-                data = violation
-            else:
-                data = asdict(violation) if hasattr(violation, "__dict__") else {}
-
-            normalized.append(
-                {
-                    "id": data.get("id") or data.get("rule_id") or data.get("violation_id") or "unknown",
-                    "rule_id": data.get("rule_id") or data.get("id") or "unknown",
-                    "type": data.get("type") or data.get("connascence_type") or data.get("category", "unknown"),
-                    "severity": data.get("severity", data.get("severity_level", "medium")),
-                    "description": data.get("description") or data.get("message", ""),
-                    "file_path": data.get("file_path") or data.get("path"),
-                    "line_number": data.get("line_number") or data.get("line"),
-                    "weight": data.get("weight", 1.0),
-                }
-            )
-        return normalized
-
-    def _count_by_severity(self, violations: List[Dict[str, Any]]) -> Dict[str, int]:
-        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
-        for violation in violations:
-            severity = violation.get("severity", "medium")
-            counts[severity] = counts.get(severity, 0) + 1
-        return counts
-
-    def _resolve_policy_snapshot(self, analysis_type: str) -> (str, Optional[Dict[str, Any]]):
-        if self.policy_manager is None or ThresholdConfig is None:
-            return "standard", None
-
+    def _resolve_profile(self, analysis_type: str) -> str:
         mapping = {
-            "full": "standard",
-            "connascence": "strict",
-            "mece": "lenient",
+            "full": "service-defaults",
+            "connascence": "strict-connascence",
+            "mece": "service-defaults",
             "nasa": "nasa-compliance",
         }
-        policy_name = mapping.get(analysis_type, "standard")
-
-        try:
-            preset = self.policy_manager.get_preset(policy_name)
-        except Exception as exc:  # pragma: no cover - only triggered when presets missing
-            logger.warning("Failed to load preset %s: %s", policy_name, exc)
-            return policy_name, None
-
-        thresholds = {
-            "max_positional_params": getattr(preset, "max_positional_params", None),
-            "god_class_methods": getattr(preset, "god_class_methods", None),
-            "max_cyclomatic_complexity": getattr(preset, "max_cyclomatic_complexity", None),
-        }
-        return policy_name, thresholds
-
-    def _ensure_result_mapping(self, analyzer_result: Any, file_path: str) -> Dict[str, Any]:
-        """Normalize analyzer outputs into a dict structure."""
-
-        if isinstance(analyzer_result, dict):
-            result = dict(analyzer_result)
-            if "connascence_violations" not in result and "violations" in result:
-                result["connascence_violations"] = result.get("violations", [])
-            result.setdefault("nasa_violations", [])
-            result.setdefault("nasa_compliance_score", 1.0)
-            result.setdefault("file_path", file_path)
-            return result
-
-        if isinstance(analyzer_result, list):
-            return {
-                "file_path": file_path,
-                "connascence_violations": analyzer_result,
-                "nasa_violations": [],
-                "nasa_compliance_score": 1.0,
-            }
-
-        return {
-            "file_path": file_path,
-            "connascence_violations": [],
-            "nasa_violations": [],
-            "nasa_compliance_score": 1.0,
-        }
+        return mapping.get(analysis_type, "service-defaults")
 
 
 __all__ = ["AnalyzerBridge"]

--- a/tests/cli/test_cli_json_contract.py
+++ b/tests/cli/test_cli_json_contract.py
@@ -1,0 +1,29 @@
+import contextlib
+import json
+from io import StringIO
+
+import pytest
+
+from interfaces.cli.connascence import ConnascenceCLI
+
+
+@pytest.mark.parametrize("content", ["def demo(x):\n    return x + 42\n", "class Demo:\n    pass\n"])
+def test_cli_analyze_outputs_json(tmp_path, monkeypatch, content):
+    cli = ConnascenceCLI()
+    target = tmp_path / "example.py"
+    target.write_text(content, encoding="utf-8")
+
+    captured = {}
+
+    def capture(payload, fmt, output_path):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(cli, "_emit_result", capture)
+
+    exit_code = cli.run(["analyze", str(target), "--format", "json"])
+
+    assert exit_code == 0
+    payload = captured["payload"]
+    assert payload["target"].endswith("example.py")
+    assert "findings" in payload
+    assert "summary" in payload

--- a/tests/mcp/test_enhanced_server_contract.py
+++ b/tests/mcp/test_enhanced_server_contract.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from mcp.enhanced_server import EnhancedConnascenceMCPServer
+
+
+def test_mcp_server_uses_cli_schema(tmp_path):
+    source = tmp_path / "contract.py"
+    source.write_text(
+        """def example(alpha, beta, gamma, delta, epsilon):\n    return alpha + beta + gamma\n""",
+        encoding="utf-8",
+    )
+
+    server = EnhancedConnascenceMCPServer()
+    result = asyncio.run(server.analyze_file(str(source)))
+
+    assert result["success"] is True
+    assert result["target"].endswith("contract.py")
+    assert "findings" in result
+    assert "summary" in result


### PR DESCRIPTION
## Summary
- add `analyzer/cli_entry.py` so the CLI, MCP server, and local clients share a single analysis helper and JSON schema
- update the CLI handlers, MCP bridge/server, and VSCode API client/tests to consume the shared helper and the new `analyze`/`analyze-workspace` CLI commands
- add regression tests that cover CLI JSON output plus MCP response contracts

## Testing
- `pytest tests/cli/test_cli_json_contract.py tests/mcp/test_enhanced_server_contract.py`
- `npm test` *(fails: ESLint configuration file is missing in interfaces/vscode)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691914987834832ca07772c5b7e5bfbc)