### PR TITLE
Add analyzer orchestration and health indicators

### DIFF
--- a/interfaces/vscode/package.json
+++ b/interfaces/vscode/package.json
@@ -155,6 +155,12 @@
         "icon": "$(debug-breakpoint-log)"
       },
       {
+        "command": "connascence.showHealth",
+        "title": "Show Analyzer Health",
+        "category": "Connascence: Diagnostics",
+        "icon": "$(pulse)"
+      },
+      {
         "command": "connascence.showWelcome",
         "title": "Show Welcome Screen",
         "category": "Connascence",

--- a/interfaces/vscode/src/commands/commandManager.ts
+++ b/interfaces/vscode/src/commands/commandManager.ts
@@ -57,7 +57,8 @@ export class CommandManager implements vscode.Disposable {
         this.commands.set('connascence.refreshFindings', this.refreshFindings.bind(this));
         this.commands.set('connascence.clearFindings', this.clearFindings.bind(this));
         this.commands.set('connascence.clearCache', this.clearCache.bind(this));
-        
+        this.commands.set('connascence.showHealth', this.showHealthSummary.bind(this));
+
         // Information commands
         this.commands.set('connascence.explainFinding', this.explainFinding.bind(this));
         this.commands.set('connascence.showError', this.showError.bind(this));
@@ -493,6 +494,20 @@ export class CommandManager implements vscode.Disposable {
 
     private async showDocumentation(): Promise<void> {
         await vscode.env.openExternal(vscode.Uri.parse('https://docs.connascence.io'));
+    }
+
+    private async showHealthSummary(): Promise<void> {
+        const health = this.connascenceService.getHealthStatus();
+        const lines = [
+            `Backend: ${health.backend.toUpperCase()}`,
+            `MCP connected: ${health.mcpConnected ? 'Yes' : 'No'}`,
+            `CLI available: ${health.cliAvailable ? `Yes (${health.cliPath || 'PATH'})` : 'No'}`,
+            `Python analyzer: ${health.pythonAvailable ? `Yes (${health.pythonPath || 'workspace'})` : 'No'}`,
+            health.lastError ? `Last error: ${health.lastError}` : undefined,
+            health.message
+        ].filter(Boolean).join('\n');
+
+        vscode.window.showInformationMessage(`Connascence Analyzer Health\n${lines}`);
     }
 
     // Helper methods

--- a/interfaces/vscode/src/features/aiFixSuggestions.ts
+++ b/interfaces/vscode/src/features/aiFixSuggestions.ts
@@ -13,6 +13,7 @@ export interface FixSuggestion {
 
 export class AIFixSuggestionsProvider {
     private static instance: AIFixSuggestionsProvider;
+    private activeFindings: Finding[] = [];
 
     private constructor() {}
 
@@ -39,6 +40,10 @@ export class AIFixSuggestionsProvider {
         }
         
         return suggestions.sort((a, b) => b.confidence - a.confidence);
+    }
+
+    public updateActiveFindings(findings: Finding[]): void {
+        this.activeFindings = findings;
     }
 
     private getRuleBasedSuggestions(finding: Finding, document: vscode.TextDocument): FixSuggestion[] {

--- a/interfaces/vscode/src/features/visualHighlighting.ts
+++ b/interfaces/vscode/src/features/visualHighlighting.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Finding } from '../services/connascenceService';
+import { Finding, NormalizedFinding } from '../services/connascenceService';
 
 export class VisualHighlightingManager {
     private decorationTypes: Map<string, vscode.TextEditorDecorationType> = new Map();
@@ -345,7 +345,7 @@ export class VisualHighlightingManager {
         this.refreshAllDecorations();
     }
 
-    public applyHighlighting(editor: vscode.TextEditor, findings: Finding[]) {
+    public applyHighlighting(editor: vscode.TextEditor, findings: (Finding | NormalizedFinding)[]) {
         const config = vscode.workspace.getConfiguration('connascence');
         const enabled = config.get<boolean>('enableVisualHighlighting', true);
         const showEmojis = config.get<boolean>('showEmojis', true);
@@ -361,7 +361,7 @@ export class VisualHighlightingManager {
         const findingsByType = new Map<string, Finding[]>();
         
         for (const finding of findings) {
-            const normalizedType = this.normalizeConnascenceType(finding.type);
+            const normalizedType = (finding as NormalizedFinding).normalizedType || this.normalizeConnascenceType(finding.type);
             if (!findingsByType.has(normalizedType)) {
                 findingsByType.set(normalizedType, []);
             }

--- a/interfaces/vscode/src/providers/analysisResultsProvider.ts
+++ b/interfaces/vscode/src/providers/analysisResultsProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Finding } from '../services/connascenceService';
+import { Finding, NormalizedFinding } from '../services/connascenceService';
 
 export class AnalysisResultItem extends vscode.TreeItem {
     constructor(
@@ -86,10 +86,10 @@ export class AnalysisResultsProvider implements vscode.TreeDataProvider<Analysis
     private _onDidChangeTreeData: vscode.EventEmitter<AnalysisResultItem | undefined | null | void> = new vscode.EventEmitter<AnalysisResultItem | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<AnalysisResultItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
-    private analysisResults: Map<string, Finding[]> = new Map();
+    private analysisResults: Map<string, (Finding | NormalizedFinding)[]> = new Map();
     private groupBy: 'file' | 'severity' | 'type' = 'file';
     private currentFilter: AnalysisFilter = {};
-    private filteredResults: Map<string, Finding[]> = new Map();
+    private filteredResults: Map<string, (Finding | NormalizedFinding)[]> = new Map();
     private showSummary: boolean = true;
     private totalFindings: number = 0;
     private lastAnalysisTime: Date | null = null;
@@ -158,7 +158,7 @@ export class AnalysisResultsProvider implements vscode.TreeDataProvider<Analysis
         }
     }
 
-    private filterFindings(findings: Finding[]): Finding[] {
+    private filterFindings(findings: (Finding | NormalizedFinding)[]): Finding[] {
         let filtered = [...findings];
 
         // Search query filter
@@ -236,7 +236,7 @@ export class AnalysisResultsProvider implements vscode.TreeDataProvider<Analysis
         this._onDidChangeTreeData.fire();
     }
 
-    updateResults(results: Map<string, Finding[]>) {
+    updateResults(results: Map<string, (Finding | NormalizedFinding)[]>) {
         this.analysisResults = results;
         this.totalFindings = Array.from(results.values()).reduce((sum, findings) => sum + findings.length, 0);
         this.lastAnalysisTime = new Date();
@@ -574,7 +574,7 @@ export class AnalysisResultsProvider implements vscode.TreeDataProvider<Analysis
         });
     }
 
-    private getFindingElements(findings: Finding[]): AnalysisResultItem[] {
+    private getFindingElements(findings: (Finding | NormalizedFinding)[]): AnalysisResultItem[] {
         return findings.map(finding => {
             const fileName = finding.file.split('/').pop() || finding.file;
             const item = new AnalysisResultItem(

--- a/interfaces/vscode/src/providers/codeActionProvider.ts
+++ b/interfaces/vscode/src/providers/codeActionProvider.ts
@@ -40,6 +40,15 @@ export class ConnascenceCodeActionProvider implements vscode.CodeActionProvider 
             vscode.CodeActionKind.QuickFix
         );
 
+        const normalizedFindings = this.connascenceService.getNormalizedFindings(document.fileName);
+        const diagnosticId = typeof diagnostic.code === 'object'
+            ? (diagnostic.code as { value?: string }).value
+            : diagnostic.code;
+        const normalized = normalizedFindings?.find(f => f.id === diagnosticId);
+        if (normalized?.emoji) {
+            action.title = `${normalized.emoji} Fix: ${diagnostic.message}`;
+        }
+
         action.diagnostics = [diagnostic];
         action.isPreferred = true;
 


### PR DESCRIPTION
## Summary
- detect CLI vs Python analyzers and surface missing-analyzer errors while the service now orchestrates MCP, CLI, Python, or cached backends with normalized finding events
- feed the normalized stream into tree views, dashboards, visual highlighting, notifications, AI helpers, and code actions while exposing analyzer health via a status-bar indicator and the new `Connascence: Show Analyzer Health` command
- refresh status/notification plumbing so users immediately see which backend is active and receive consistent emojis and metadata across the extension

## Testing
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919153dd3dc832c878acc4d0d452f69)