### PR TITLE
Add analyzer orchestration and health surfacing

### DIFF
--- a/interfaces/vscode/package.json
+++ b/interfaces/vscode/package.json
@@ -167,6 +167,12 @@
         "icon": "$(clear-all)"
       },
       {
+        "command": "connascence.showHealthStatus",
+        "title": "Show Analyzer Health",
+        "category": "Connascence: Utilities",
+        "icon": "$(heartbeat)"
+      },
+      {
         "command": "connascence.refreshAnalysis",
         "title": "Refresh Analysis",
         "category": "Connascence: Utilities",
@@ -239,6 +245,9 @@
         {
           "command": "connascence.refreshAnalysis",
           "when": "workspaceFolderCount > 0"
+        },
+        {
+          "command": "connascence.showHealthStatus"
         }
       ],
       "editor/context": [

--- a/interfaces/vscode/src/features/aiFixSuggestions.ts
+++ b/interfaces/vscode/src/features/aiFixSuggestions.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { Finding } from '../services/connascenceService';
 
 export interface FixSuggestion {
@@ -13,6 +14,7 @@ export interface FixSuggestion {
 
 export class AIFixSuggestionsProvider {
     private static instance: AIFixSuggestionsProvider;
+    private cachedFindings: Map<string, Finding[]> = new Map();
 
     private constructor() {}
 
@@ -21,6 +23,14 @@ export class AIFixSuggestionsProvider {
             AIFixSuggestionsProvider.instance = new AIFixSuggestionsProvider();
         }
         return AIFixSuggestionsProvider.instance;
+    }
+
+    public cacheFindings(filePath: string, findings: Finding[]): void {
+        this.cachedFindings.set(path.resolve(filePath), findings);
+    }
+
+    public getCachedFindings(filePath: string): Finding[] | undefined {
+        return this.cachedFindings.get(path.resolve(filePath));
     }
 
     public async generateFixSuggestions(finding: Finding, document: vscode.TextDocument): Promise<FixSuggestion[]> {

--- a/interfaces/vscode/src/providers/analysisResultsProvider.ts
+++ b/interfaces/vscode/src/providers/analysisResultsProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Finding } from '../services/connascenceService';
+import { AnalysisResult, Finding } from '../services/connascenceService';
 
 export class AnalysisResultItem extends vscode.TreeItem {
     constructor(
@@ -239,6 +239,24 @@ export class AnalysisResultsProvider implements vscode.TreeDataProvider<Analysis
     updateResults(results: Map<string, Finding[]>) {
         this.analysisResults = results;
         this.totalFindings = Array.from(results.values()).reduce((sum, findings) => sum + findings.length, 0);
+        this.lastAnalysisTime = new Date();
+        this.applyFilters();
+        this.refresh();
+    }
+
+    ingestFileResult(filePath: string, findings: Finding[]): void {
+        this.analysisResults.set(filePath, findings);
+        this.totalFindings = Array.from(this.analysisResults.values()).reduce((sum, fileFindings) => sum + fileFindings.length, 0);
+        this.lastAnalysisTime = new Date();
+        this.applyFilters();
+        this.refresh();
+    }
+
+    ingestWorkspaceResults(results: { [filePath: string]: AnalysisResult }): void {
+        for (const [filePath, analysis] of Object.entries(results)) {
+            this.analysisResults.set(filePath, analysis.findings);
+        }
+        this.totalFindings = Array.from(this.analysisResults.values()).reduce((sum, fileFindings) => sum + fileFindings.length, 0);
         this.lastAnalysisTime = new Date();
         this.applyFilters();
         this.refresh();


### PR DESCRIPTION
## Summary
- detect the packaged CLI binary or Python entry point at startup so analyzer availability errors bubble up explicitly
- add backend orchestration, caching, and normalized analysis events so dashboards, notifications, AI fixes, and highlights stay in sync
- surface analyzer health via status bar + command palette and route findings into dashboards, notifications, and AI/code actions through the shared cache

## Testing
- `npm run compile`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191ead2c80832c83d877fa3fbe10e9)