### PR TITLE
Fix metrics aggregation and tighten report handling

### DIFF
--- a/analyzer/architecture/stream_processor.py
+++ b/analyzer/architecture/stream_processor.py
@@ -20,6 +20,7 @@ NASA Compliance:
 
 import asyncio
 import logging
+import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -329,7 +330,7 @@ class StreamProcessor:
         return {
             "batch_size": len(batch),
             "files": [str(f) for f in batch],
-            "timestamp": asyncio.get_event_loop().time(),
+            "timestamp": time.time(),
         }
 
     def process_stream(self, file_changes: List[Path]) -> Dict[str, Any]:
@@ -423,7 +424,8 @@ class StreamProcessor:
             return False
 
         try:
-            return self.stream_processor.is_running
+            status = self.stream_processor.is_running
+            return status if isinstance(status, bool) else False
         except Exception:
             return False
 

--- a/tests/unit/test_stream_processor.py
+++ b/tests/unit/test_stream_processor.py
@@ -29,6 +29,15 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    """Force anyio to use asyncio backend to avoid optional trio dependency."""
+    return "asyncio"
+
 # Import the component under test
 from analyzer.architecture.stream_processor import (
     StreamProcessor,


### PR DESCRIPTION
## Summary
- avoid counting duplication clusters as violations and stop baseline snapshots from polluting history
- validate report output paths to reject unsupported Windows system locations
- stabilize stream processor helpers and tests by using the asyncio backend and avoiding missing event loops

## Testing
- pytest tests/unit/test_metrics_collector.py tests/unit/test_report_generator.py tests/unit/test_stream_processor.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a27c8930832ca0831118a48fcad0)