### PR TITLE
Reset literal tracking between ValuesDetector analyses

### DIFF
--- a/analyzer/detectors/values_detector.py
+++ b/analyzer/detectors/values_detector.py
@@ -47,6 +47,11 @@ class ValuesDetector(DetectorBase):
         """
         self.violations.clear()
 
+        # Reset tracked literals for each analysis run to avoid cross-file leakage
+        # when detectors are pooled and reused across files.
+        self.string_literals.clear()
+        self.numeric_literals.clear()
+
         # Find all Constant nodes (Python 3.8+ unified constant handling)
         for node in ast.walk(tree):
             if isinstance(node, ast.Constant):


### PR DESCRIPTION
## Summary
- clear cached literal tracking in ValuesDetector before each analysis run to prevent cross-file leakage when detectors are reused

## Testing
- not run (pytest dependency pytest_asyncio missing in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a27c8930832ca0831118a48fcad0)