### PR TITLE
Add missing agent fixture and improve CLI report outputs

### DIFF
--- a/analyzer/cli_entry.py
+++ b/analyzer/cli_entry.py
@@ -204,8 +204,10 @@ class SharedCLIAnalyzer:
             "profile": profile,
             "quality_score": quality_score,
             "findings": findings,
+            "violations": findings,
             "summary": {"totalIssues": len(findings), "issuesBySeverity": severity_summary},
             "files_analyzed": files_analyzed,
+            "total_files_analyzed": files_analyzed,
         }
 
         if analysis_time is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ bcrypt>=4.0.0
 
 # Development dependencies (optional)
 pytest>=7.0
+pytest-asyncio>=0.23
 pytest-cov>=4.0
 black>=22.0
 ruff>=0.1.0

--- a/tests/agents/core/fixtures/conftest.py
+++ b/tests/agents/core/fixtures/conftest.py
@@ -62,3 +62,108 @@ class MockAgentInterface:
             "messaging": True,
             "task_processing": True,
         }
+
+
+class MockTestAgent:
+    """Reference implementation used by the compliance test suite."""
+
+    def __init__(self):
+        self.messages: List[Dict[str, Any]] = []
+        self.tasks_processed: List[Any] = []
+        self.capabilities: Dict[str, Any] = {
+            "messaging": True,
+            "embeddings": True,
+            "reranking": True,
+            "health_check": True,
+            "task_processing": True,
+            "synthetic": False,
+        }
+        self.status: Dict[str, Any] = {
+            "state": "initialized",
+            "last_broadcast": 0,
+            "last_channel": None,
+        }
+
+    # Lifecycle operations
+    def initialize(self) -> bool:
+        self.status["state"] = "ready"
+        return True
+
+    def shutdown(self) -> bool:
+        self.status["state"] = "shutdown"
+        return True
+
+    # Capability and health interfaces
+    def health_check(self) -> Dict[str, Any]:
+        return {
+            "status": self.status.get("state", "ready"),
+            "components": {"messaging": "ok", "tasks": len(self.tasks_processed)},
+        }
+
+    def get_capabilities(self) -> Dict[str, Any]:
+        return dict(self.capabilities)
+
+    def activate_latent_space(self, mode: str) -> bool:
+        self.capabilities["synthetic"] = True
+        self.status["latent_mode"] = mode
+        return True
+
+    # Task handling
+    def can_handle_task(self, task: Dict[str, Any]) -> bool:
+        return task.get("type") in {"echo", "synthetic"}
+
+    def process_task(self, task: Dict[str, Any], context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        self.tasks_processed.append(task)
+        if task.get("type") == "echo":
+            return {
+                "status": "completed",
+                "task": task,
+                "echo": task.get("payload"),
+                "context": context or {},
+            }
+        return {"status": "unsupported", "task": task}
+
+    def estimate_task_duration(self, task: Dict[str, Any]) -> float:
+        return 0.1 if self.can_handle_task(task) else 1.0
+
+    # Messaging helpers
+    def send_message(self, recipient: str, message: str, **kwargs) -> Dict[str, Any]:
+        envelope = {"recipient": recipient, "message": message, "delivered": True, **kwargs}
+        self.messages.append(envelope)
+        return envelope
+
+    def receive_message(self, timeout: float | None = None) -> List[Dict[str, Any]]:
+        return list(self.messages)
+
+    def broadcast_message(self, recipients: List[str], message: str) -> List[Dict[str, Any]]:
+        receipts = [self.send_message(r, message) for r in recipients]
+        self.status["last_broadcast"] = len(recipients)
+        return receipts
+
+    def communicate(self, channel: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self.status["last_channel"] = channel
+        return {"channel": channel, "acknowledged": True, "payload": payload}
+
+    # Generation, embeddings, and ranking
+    def generate(self, prompt: str, tone: str = "neutral") -> str:
+        return f"[{tone}] {prompt}"
+
+    def get_embedding(self, text: str) -> List[int]:
+        return [len(text), len(text.split())]
+
+    def rerank(self, items: List[Any], query: str) -> List[Any]:
+        return sorted(items, key=lambda item: str(item))
+
+    def introspect(self) -> Dict[str, Any]:
+        return {"status": self.status, "capabilities": self.capabilities}
+
+    # Telemetry helpers used by integration tests
+    def get_status(self) -> Dict[str, Any]:
+        return dict(self.status)
+
+    def get_performance_metrics(self) -> Dict[str, Any]:
+        return {
+            "messages": len(self.messages),
+            "tasks_processed": len(self.tasks_processed),
+            "latency_seconds": 0.01,
+        }

--- a/tests/integration/test_mcp_server_integration.py
+++ b/tests/integration/test_mcp_server_integration.py
@@ -26,7 +26,8 @@ import time
 from typing import Any, Dict
 
 import pytest
-import pytest_asyncio
+
+pytest_asyncio = pytest.importorskip("pytest_asyncio")
 
 # Memory coordination for test results
 TEST_MEMORY = {}


### PR DESCRIPTION
## Summary
- add a comprehensive `MockTestAgent` fixture for agent contract tests
- align CLI JSON, text, and markdown outputs with validation expectations
- handle optional pytest-asyncio dependency for MCP integration tests and document it in requirements

## Testing
- pytest tests/e2e/test_cli_workflows.py::TestCLIWorkflowsEndToEnd::test_output_format_workflow -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a27c8930832ca0831118a48fcad0)