### PR TITLE
ci: make NASA critical gate fail closed

### DIFF
--- a/.github/workflows/nasa-compliance-check.yml
+++ b/.github/workflows/nasa-compliance-check.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  PYTHON_VERSION: '3.8'
+  PYTHON_VERSION: '3.11'
 
 jobs:
   nasa-compliance:
@@ -331,8 +331,8 @@ jobs:
             },
             'connascence_analysis': 'completed',
             'mece_analysis': 'completed',
-            # Not a hardcoded pass: the build-failing decision is the critical-violation
-            # gate above (sys.exit(1)). Rules 6-9 are 'todo' (unenforced), so this report
+            # Not a hardcoded pass: the final checker step below makes the build-failing
+            # decision. Rules 6-9 are 'todo' (unenforced), so this report
             # is explicitly partial, not a green light.
             'overall_status': 'partial_rules_6_9_unenforced'
         }
@@ -375,32 +375,4 @@ jobs:
         echo "**Reports available in artifacts**" >> $GITHUB_STEP_SUMMARY
     
     - name: Fail on Critical Violations
-      run: |
-        echo "Checking for critical NASA violations..."
-        
-        # This would fail the build if critical violations are found
-        # For now, we'll make it a warning
-        if [ -f nasa-connascence-report.json ]; then
-          python3 << 'EOF'
-        import json
-        import sys
-        
-        try:
-            with open('nasa-connascence-report.json', 'r') as f:
-                report = json.load(f)
-            
-            violations = report.get('violations', [])
-            critical_violations = [v for v in violations if v.get('severity') == 'critical']
-            
-            if len(critical_violations) > 5:  # Allow some critical violations for now
-                print(f"[FAIL] Too many critical violations: {len(critical_violations)}")
-                print("Build fails: critical NASA-compliance violations present")
-                sys.exit(1)
-            else:
-                print(f"[OK] Critical violations within acceptable range: {len(critical_violations)}")
-        except:
-            print("[WARN] Could not evaluate critical violations")
-        EOF
-        fi
-        
-        echo "[OK] NASA Power of Ten compliance check completed"
+      run: python scripts/check_nasa_critical.py nasa-connascence-report.json

--- a/scripts/check_nasa_critical.py
+++ b/scripts/check_nasa_critical.py
@@ -1,0 +1,39 @@
+"""Fail-closed gate for the NASA critical-violation report."""
+
+import json
+import sys
+from pathlib import Path
+
+LIMIT = 5
+
+
+def main(argv) -> int:
+    if len(argv) != 2:
+        print("NASA_CRITICAL_GATE_INVALID expected_report_path", file=sys.stderr)
+        return 2
+
+    try:
+        report = json.loads(Path(argv[1]).read_text(encoding="utf-8"))
+        if report.get("success") is not True:
+            raise ValueError("analyzer did not report success")
+        violations = report["violations"]
+        if not isinstance(violations, list) or not all(
+            isinstance(item, dict) and isinstance(item.get("severity"), str)
+            for item in violations
+        ):
+            raise ValueError("violations must be a list of objects")
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        print(f"NASA_CRITICAL_GATE_INVALID {type(error).__name__}", file=sys.stderr)
+        return 2
+
+    critical = sum(item.get("severity") == "critical" for item in violations)
+    if critical > LIMIT:
+        print(f"NASA_CRITICAL_GATE_RED critical={critical} limit={LIMIT}")
+        return 1
+
+    print(f"NASA_CRITICAL_GATE_GREEN critical={critical} limit={LIMIT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_ci_honesty.py
+++ b/tests/test_ci_honesty.py
@@ -1,16 +1,75 @@
-"""Guards that the NASA-compliance workflow can no longer hardcode a pass."""
+"""Behavioral proof that the NASA critical-violation gate fails closed."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_nasa_critical.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "nasa-compliance-check.yml"
 
 
-def test_nasa_workflow_has_no_hardcoded_pass():
-    text = (ROOT / ".github" / "workflows" / "nasa-compliance-check.yml").read_text(encoding="utf-8")
-    assert "passed_with_warnings" not in text, "workflow still hardcodes an overall pass"
+def run_checker(report: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), str(report)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
-def test_nasa_workflow_can_fail_the_build():
-    text = (ROOT / ".github" / "workflows" / "nasa-compliance-check.yml").read_text(encoding="utf-8")
-    # the critical-violation gate must be a live sys.exit(1), not a commented one
-    assert "sys.exit(1)" in text
-    assert "# sys.exit(1)" not in text
+def write_report(path: Path, critical: int) -> None:
+    violations = [{"severity": "critical"} for _ in range(critical)]
+    path.write_text(json.dumps({"success": True, "violations": violations}), encoding="utf-8")
+
+
+def test_checker_accepts_policy_limit(tmp_path: Path):
+    report = tmp_path / "report.json"
+    write_report(report, 5)
+
+    result = run_checker(report)
+
+    assert result.returncode == 0
+    assert "NASA_CRITICAL_GATE_GREEN critical=5 limit=5" in result.stdout
+
+
+def test_checker_rejects_excess_critical_violations(tmp_path: Path):
+    report = tmp_path / "report.json"
+    write_report(report, 6)
+
+    result = run_checker(report)
+
+    assert result.returncode == 1
+    assert "NASA_CRITICAL_GATE_RED critical=6 limit=5" in result.stdout
+
+
+@pytest.mark.parametrize("case", ["missing", "malformed", "invalid_schema", "analyzer_failed"])
+def test_checker_rejects_unreadable_reports(tmp_path: Path, case: str):
+    report = tmp_path / "report.json"
+    if case == "malformed":
+        report.write_text("not json", encoding="utf-8")
+    elif case == "invalid_schema":
+        report.write_text(json.dumps({"success": True, "violations": [{}]}), encoding="utf-8")
+    elif case == "analyzer_failed":
+        report.write_text(json.dumps({"success": False, "violations": []}), encoding="utf-8")
+
+    result = run_checker(report)
+
+    assert result.returncode == 2
+    assert "NASA_CRITICAL_GATE_INVALID" in result.stderr
+
+
+def test_workflow_invokes_checker_without_soft_fail():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    step = text.split("- name: Fail on Critical Violations", 1)[1].split("\n    - name:", 1)[0]
+
+    assert "python scripts/check_nasa_critical.py nasa-connascence-report.json" in step
+    assert "continue-on-error" not in step
+    assert "||" not in step
+    assert "if [ -f" not in step


### PR DESCRIPTION
## Summary

- replace the inline NASA critical-violation heredoc with a small, testable stdlib checker
- fail closed on missing, malformed, failed-analyzer, or invalid-schema reports
- run the NASA workflow on Python 3.11 because the analyzer uses Python 3.10+ syntax
- replace string-presence tests with behavioral subprocess tests

## Fail-first evidence

The old workflow printed `[FAIL] Too many critical violations` for six critical findings, then its bare `except:` caught `SystemExit` and the step exited 0. Missing and malformed reports also passed.

## Verification

- boundary fixtures: five critical findings pass; six fail
- missing, malformed, invalid schema, and `success:false` reports fail closed
- focused ledger gate: 7 passed
- Python 3.8 test-module import passes after deferred annotations
- real analyzer runs on Python 3.11 and produces the expected schema
- YAML parse and diff checks pass
- independent Codex-agent and Claude Sonnet Crucible audits pass

The current repository produces 121 critical findings, so the repaired NASA workflow is expected to be red until that debt is reduced below the existing limit of five. This PR makes the existing policy truthful; it does not claim the codebase already satisfies it.
